### PR TITLE
修复ReferenceConllector方法名Get和Get<>在ILRuntime中运行冲突导致异常，重现方法:1.Hotfix工程调用Get(string key) 2.生产Binding代码By分析 3.运行异常System.Reflection.AmbiguousMatchException: Ambiguous match found.(at System.DefaultBinder.SelectMethod)

### DIFF
--- a/Unity/Assets/Scripts/Other/ReferenceCollector.cs
+++ b/Unity/Assets/Scripts/Other/ReferenceCollector.cs
@@ -109,7 +109,7 @@ public class ReferenceCollector: MonoBehaviour, ISerializationCallbackReceiver
 		return dictGo as T;
 	}
 
-	public Object Get(string key)
+	public Object GetObject(string key)
 	{
 		Object dictGo;
 		if (!dict.TryGetValue(key, out dictGo))


### PR DESCRIPTION
修复ReferenceConllector方法名Get和Get<>在ILRuntime中运行冲突导致异常，重现方法:1.Hotfix工程调用Get(string key) 2.生产Binding代码By分析 3.运行异常System.Reflection.AmbiguousMatchException: Ambiguous match found.(at System.DefaultBinder.SelectMethod)