### PR TITLE
修复反序列化配置数据时，LitJson不支持float类型的错误

### DIFF
--- a/Unity/Assets/ThirdParty/ILRuntime/LitJson/JsonMapper.cs
+++ b/Unity/Assets/ThirdParty/ILRuntime/LitJson/JsonMapper.cs
@@ -714,6 +714,8 @@ namespace LitJson
             };
             RegisterImporter (base_importers_table, typeof (string),
                               typeof (DateTime), importer);
+            
+            RegisterImporter<double, float>(input => Convert.ToSingle(input));
         }
 
         private static void RegisterImporter (
@@ -752,6 +754,11 @@ namespace LitJson
 
             if (obj is String) {
                 writer.Write ((string) obj);
+                return;
+            }
+            
+            if (obj is Single) {
+                writer.Write((float)obj);
                 return;
             }
 

--- a/Unity/Assets/ThirdParty/ILRuntime/LitJson/JsonWriter.cs
+++ b/Unity/Assets/ThirdParty/ILRuntime/LitJson/JsonWriter.cs
@@ -225,7 +225,7 @@ namespace LitJson
 
             writer.Write ('"');
 
-	        //Ö±½Ó´æ´¢Ô­Ê¼×Ö·û´®£¬²»ÔÙ×öÈÎºÎ×ªÒå×Ö·ûµÄ½âÎö
+	        //Ö±ï¿½Ó´æ´¢Ô­Ê¼ï¿½Ö·ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Îºï¿½×ªï¿½ï¿½ï¿½Ö·ï¿½ï¿½Ä½ï¿½ï¿½ï¿½
 	        writer.Write(str);
 	        writer.Write('"');
 	        return;
@@ -463,6 +463,17 @@ namespace LitJson
                 writer.Write (':');
 
             context.ExpectingValue = true;
+        }
+        
+        public void Write(float number)
+        {
+            DoValidation(Condition.Value);
+            PutNewline();
+ 
+            string str = number.ToString();
+            Put(str);
+ 
+            context.ExpectingValue = false;
         }
     }
 }


### PR DESCRIPTION
参考了以下博文的处理方式:

Litjson添加对float类型的支持
https://blog.csdn.net/fanshusa/article/details/86656275