### PR TITLE
修复BundleDownloadrComponent使用完后没有从Game.Scene中移除的bug

### DIFF
--- a/Unity/Assets/Model/Module/AssetsBundle/BundleDownloaderComponent.cs
+++ b/Unity/Assets/Model/Module/AssetsBundle/BundleDownloaderComponent.cs
@@ -32,6 +32,30 @@ namespace ETModel
 		public string downloadingBundle;
 
 		public UnityWebRequestAsync webRequest;
+		
+		public override void Dispose()
+		{
+				if (this.IsDisposed)
+				{
+						return;
+				}
+
+				if (this.Entity.IsDisposed)
+				{
+						return;
+				}
+
+				base.Dispose();
+
+				this.remoteVersionConfig = null;
+				this.TotalSize = 0;
+				this.bundles = null;
+				this.downloadedBundles = null;
+				this.downloadingBundle = null;
+				this.webRequest?.Dispose();
+
+				this.Entity.RemoveComponent<BundleDownloaderComponent>();
+		}
 
 		public async ETTask StartAsync()
 		{


### PR DESCRIPTION
第一次在using中使用完BundleDownloadrComponent之后，BundleDownloadrComponent并没有从Game.Scene中移除。如果第二次使用，Game.Scene.AddComponent()会报重复添加组件的错误。