### PR TITLE
优化EndInit的调用时机，避免DeserializeSystem中GetComponent出现空指针的错误。

### DIFF
--- a/Unity/Assets/Hotfix/Base/Object/Entity.cs
+++ b/Unity/Assets/Hotfix/Base/Object/Entity.cs
@@ -232,9 +232,7 @@ namespace ETHotfix
 		public override void EndInit()
 		{
 			try
-			{
-				base.EndInit();
-				
+			{				
 				this.componentDict.Clear();
 
 				if (this.components != null)
@@ -245,6 +243,8 @@ namespace ETHotfix
 						this.componentDict.Add(component.GetType(), component);
 					}
 				}
+
+        base.EndInit();
 			}
 			catch (Exception e)
 			{

--- a/Unity/Assets/Model/Base/Object/Entity.cs
+++ b/Unity/Assets/Model/Base/Object/Entity.cs
@@ -232,9 +232,7 @@ namespace ETModel
 		public override void EndInit()
 		{
 			try
-			{
-				base.EndInit();
-				
+			{				
 				this.componentDict.Clear();
 
 				if (this.components != null)
@@ -245,6 +243,8 @@ namespace ETModel
 						this.componentDict.Add(component.GetType(), component);
 					}
 				}
+
+        base.EndInit();
 			}
 			catch (Exception e)
 			{


### PR DESCRIPTION
如果EndInit调用时机过早，这会导致componentDict为空，如果此时在DeserializeSystem中调用GetComponent()，会报空指针错误。