### PR TITLE
添加断点续传组件 和 修改热更下载组件

### DIFF
--- a/Unity/Assets/Model/Module/UnityWebRequest/UnityWebRequestRenewalAsync.cs
+++ b/Unity/Assets/Model/Module/UnityWebRequest/UnityWebRequestRenewalAsync.cs
@@ -211,7 +211,7 @@ namespace ET
                 this.headRequest.SendWebRequest();
                 await this.tcs.Task;
                 this.totalBytes = long.Parse(this.headRequest.GetResponseHeader("Content-Length"));
-                Log.Debug($"totalBytes {this.totalBytes.ToGMK2()}");
+                Log.Debug($"totalBytes {this.totalBytes}");
                 this.headRequest?.Dispose();
                 this.headRequest = null;
 
@@ -226,7 +226,7 @@ namespace ET
                 fileStream = new FileStream(filePath, FileMode.OpenOrCreate, FileAccess.Write);
                 //获取已下载长度
                 this.byteWrites = fileStream.Length;
-                Log.Debug($"byteWrites {this.byteWrites.ToGMK2()}");
+                Log.Debug($"byteWrites {this.byteWrites}");
                 if (this.byteWrites == this.totalBytes)
                 {
                     Log.Debug("已经下载完成2");

--- a/Unity/Assets/Model/Module/UnityWebRequest/UnityWebRequestRenewalAsync.cs
+++ b/Unity/Assets/Model/Module/UnityWebRequest/UnityWebRequestRenewalAsync.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine.Networking;
+
+namespace ET
+{
+    public class UnityWebRequestRenewalUpdateSystem: UpdateSystem<UnityWebRequestRenewalAsync>
+    {
+        public override void Update(UnityWebRequestRenewalAsync self)
+        {
+            self.Update();
+        }
+    }
+
+    /// <summary>
+    /// 断点续传实现
+    /// </summary>
+    public class UnityWebRequestRenewalAsync: Entity
+    {
+        public class AcceptAllCertificate: CertificateHandler
+        {
+            protected override bool ValidateCertificate(byte[] certificateData)
+            {
+                return true;
+            }
+        }
+
+        public static AcceptAllCertificate certificateHandler = new AcceptAllCertificate();
+
+        public UnityWebRequest headRequest;
+
+        public bool isCancel;
+
+        public ETTaskCompletionSource tcs;
+
+        //请求资源类型
+        private class RequestType
+        {
+            public const int None = 0; //未开始
+            public const int Head = 1; //文件头
+            public const int Data = 2; //文件数据
+        }
+
+        //当前请求资源类型
+        private int requestType = RequestType.None;
+
+        //多任务同时请求
+        private readonly List<UnityWebRequest> dataRequests = new List<UnityWebRequest>();
+
+        //当前下载的文件流 边下边存文件流
+        private FileStream fileStream;
+
+        //资源地址
+        private string Url;
+
+        //每个下载包长度
+        private int packageLength = 1000000; //1M
+
+        //同时开启任务最大个数
+        private int maxCount = 20;
+
+        //已经写入文件的大小
+        private long byteWrites;
+
+        //文件总大小
+        private long totalBytes;
+
+        //当前请求的位置
+        private long downloadIndex;
+
+        //文件下载是否出错
+        private string dataError
+        {
+            get
+            {
+                foreach (UnityWebRequest webRequest in this.dataRequests)
+                    if (!string.IsNullOrEmpty(webRequest.error))
+                        return webRequest.error;
+                return "";
+            }
+        }
+
+        //批量开启任务下载
+        void DownloadPackages()
+        {
+            if (dataRequests.Count >= maxCount || this.downloadIndex == totalBytes - 1)
+                return;
+
+            //开启一个下载任务
+            void DownloadPackage(long start, long end)
+            {
+                this.downloadIndex = end;
+                Log.Debug($"Request Data ({start}~{end}):{Url}");
+                UnityWebRequest request = UnityWebRequest.Get(Url);
+                dataRequests.Add(request);
+                request.certificateHandler = certificateHandler;
+                request.SetRequestHeader("Range", $"bytes={start}-{end}");
+                request.SendWebRequest();
+            }
+
+            //开启批量下载
+            for (int i = dataRequests.Count; i < maxCount; i++)
+            {
+                long start = this.byteWrites + i * packageLength;
+                long end   = this.byteWrites + (i + 1) * packageLength - 1;
+                if (end > this.totalBytes)
+                    end = this.totalBytes - 1;
+                DownloadPackage(start, end);
+                if (end == this.totalBytes - 1)
+                    break;
+            }
+        }
+
+        //一次批量下载完成后写文件
+        void WritePackages()
+        {
+            //写入单个包
+            void WritePackage(UnityWebRequest webRequest)
+            {
+                byte[] buff = webRequest.downloadHandler.data;
+                if (buff != null && buff.Length > 0)
+                {
+                    this.fileStream.Write(buff, 0, buff.Length);
+                    this.byteWrites += buff.Length;
+                }
+
+                Log.Debug($"write file Length:{byteWrites}");
+            }
+
+            //从第一个开始顺序写入
+            while (this.dataRequests.Count > 0 && dataRequests[0].isDone)
+            {
+                UnityWebRequest first = dataRequests[0];
+                dataRequests.RemoveAt(0);
+                WritePackage(first);
+                first.Dispose();
+            }
+        }
+
+        //更新文件体下载
+        void UpdatePackages()
+        {
+            if (this.isCancel)
+            {
+                this.tcs.SetException(new Exception($"request data error: {dataError}"));
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(dataError))
+            {
+                this.tcs.SetException(new Exception($"request data error: {dataError}"));
+                return;
+            }
+
+            this.WritePackages();
+            if (this.byteWrites == this.totalBytes)
+                this.tcs.SetResult();
+            else
+                this.DownloadPackages();
+        }
+
+        //更新文件头下载
+        void UpdateHead()
+        {
+            if (this.isCancel)
+            {
+                this.tcs.SetException(new Exception($"request error: {this.headRequest.error}"));
+                return;
+            }
+
+            if (!this.headRequest.isDone)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(this.headRequest.error))
+            {
+                this.tcs.SetException(new Exception($"request error: {this.headRequest.error}"));
+                return;
+            }
+
+            this.tcs.SetResult();
+        }
+
+        /// <summary>
+        /// 断点续传入口
+        /// </summary>
+        /// <param name="url">文件下载地址</param>
+        /// <param name="filePath">文件写入路径</param>
+        /// <param name="packageLength">单个任务包体字节大小</param>
+        /// <param name="maxCount">同时开启最大任务个数</param>
+        /// <returns></returns>
+        public async ETTask DownloadAsync(string url, string filePath, int packageLength = 1000000, int maxCount = 20)
+        {
+            try
+            {
+                url                = url.Replace(" ", "%20");
+                this.Url           = url;
+                this.packageLength = packageLength;
+                this.maxCount      = maxCount;
+                Log.Debug("Web Request:" + url);
+
+                #region Download File Header
+
+                this.requestType = RequestType.Head;
+                //下载文件头
+                Log.Debug($"Request Head: {Url}");
+                this.tcs         = new ETTaskCompletionSource();
+                this.headRequest = UnityWebRequest.Head(Url);
+                this.headRequest.SendWebRequest();
+                await this.tcs.Task;
+                this.totalBytes = long.Parse(this.headRequest.GetResponseHeader("Content-Length"));
+                Log.Debug($"totalBytes {this.totalBytes.ToGMK2()}");
+                this.headRequest?.Dispose();
+                this.headRequest = null;
+
+                #endregion
+
+                #region Check Local File
+
+                var dirPath = Path.GetDirectoryName(filePath);
+                //如果路径不存在就创建
+                dirPath.CreateDirectory();
+                //打开或创建
+                fileStream = new FileStream(filePath, FileMode.OpenOrCreate, FileAccess.Write);
+                //获取已下载长度
+                this.byteWrites = fileStream.Length;
+                Log.Debug($"byteWrites {this.byteWrites.ToGMK2()}");
+                if (this.byteWrites == this.totalBytes)
+                {
+                    Log.Debug("已经下载完成2");
+                    return;
+                }
+
+                //设置开始写入位置
+                fileStream.Seek(this.byteWrites, SeekOrigin.Begin);
+
+                #endregion
+
+                #region Download File Data
+
+                //下载文件数据
+                requestType = RequestType.Data;
+                Log.Debug($"Request Data: {Url}");
+                this.tcs = new ETTaskCompletionSource();
+                this.DownloadPackages();
+                await this.tcs.Task;
+
+                #endregion
+            }
+            catch (Exception e)
+            {
+                Log.Error($"下载:{Url} Exception:{e}");
+                throw;
+            }
+        }
+
+        //下载进度
+        public float Progress
+        {
+            get
+            {
+                if (this.totalBytes == 0)
+                    return 0;
+                return (float) ((this.byteWrites + ByteDownloaded) / (double) this.totalBytes);
+            }
+        }
+
+        //当前任务已经下载的长度
+        public long ByteDownloaded
+        {
+            get
+            {
+                long length = 0;
+                foreach (UnityWebRequest dataRequest in this.dataRequests)
+                    length += dataRequest.downloadHandler.data.Length;
+                return length;
+            }
+        }
+
+        public void Update()
+        {
+            if (this.requestType == RequestType.Head)
+                this.UpdateHead();
+            if (this.requestType == RequestType.Data)
+                this.UpdatePackages();
+        }
+
+        public override void Dispose()
+        {
+            if (this.IsDisposed)
+            {
+                return;
+            }
+
+            base.Dispose();
+            headRequest?.Dispose();
+            headRequest = null;
+            foreach (UnityWebRequest dataRequest in this.dataRequests)
+                dataRequest.Dispose();
+            dataRequests.Clear();
+            this.fileStream?.Close();
+            this.fileStream?.Dispose();
+            this.fileStream = null;
+            this.isCancel   = false;
+        }
+    }
+}

--- a/Unity/Unity.Model.csproj
+++ b/Unity/Unity.Model.csproj
@@ -198,6 +198,7 @@
      <Compile Include="Assets\Model\Module\Resource\ResourcesComponent.cs" />
      <Compile Include="Assets\Model\Module\Resource\VersionConfig.cs" />
      <Compile Include="Assets\Model\Module\UnityWebRequest\UnityWebRequestAsync.cs" />
+     <Compile Include="Assets\Model\Module\UnityWebRequest\UnityWebRequestRenewalAsync.cs" />
      <Compile Include="Assets\Model\Session\SessionComponent.cs" />
      <Compile Include="Assets\Model\Unit\TurnComponent.cs" />
      <Compile Include="Assets\Model\Unit\Unit.cs" />


### PR DESCRIPTION
**添加断点续传组件**

                //支持断点续传
                //支持多任务同时下载
                //支持指定最大同时下载任务个数
                //支持指定单个任务包体大小
                //下载40M的apk 单任务下载需要60s 最大任务数量20单包1000000字节时间5s 


**修改热更Bundle组件 添加多任务下载Bundle**

                //最多同时下载n个文件 下载60M(400~500)个文件测试时间(ms)对比
                //等待n个任务同时完成再继续 1~61616 2~44796 3~34377 4~31918 5~27184 6~25564 7~22817 8~22719
                //完成1个补充1个最大n个任务 1~60309 8~11871 9~10843 10~10600 15~9309 20~9146 100~9195
                //最大任务数量20 速度从61s提升到9s

以上测试都是在同样的环境下进行