### PR TITLE
修复断线以后player没有移除的问题

### DIFF
--- a/Server/Hotfix/Demo/SessionPlayerComponentSystem.cs
+++ b/Server/Hotfix/Demo/SessionPlayerComponentSystem.cs
@@ -8,7 +8,7 @@ namespace ET
 		{
 			// 发送断线消息
 			ActorLocationSenderComponent.Instance.Send(self.Player.UnitId, new G2M_SessionDisconnect());
-			Game.Scene.GetComponent<PlayerComponent>()?.Remove(self.Player.Id);
+			self.Domain.GetComponent<PlayerComponent>()?.Remove(self.Player.Id);
 		}
 	}
 }


### PR DESCRIPTION
PlayerComponent取错了，应该是self.Domain.GetComponent<PlayerComponent>()