### PR TITLE
Android打包后卡住不能进入游戏

### DIFF
--- a/Unity/Assets/Model/Module/Resource/ResourcesComponent.cs
+++ b/Unity/Assets/Model/Module/Resource/ResourcesComponent.cs
@@ -385,8 +385,9 @@ namespace ET
 
             if (!Define.IsAsync)
             {
-                string[] realPath = null;
+                
 #if UNITY_EDITOR
+				string[] realPath = null;
                 realPath = AssetDatabase.GetAssetPathsFromAssetBundle(assetBundleName);
                 foreach (string s in realPath)
                 {
@@ -542,11 +543,13 @@ namespace ET
                 p = Path.Combine(PathHelper.AppResPath, assetBundleName);
             }
 
-            if (!File.Exists(p))
-            {
-                Log.Error("Async load bundle not exist! BundleName : " + p);
-                return null;
-            }
+            Log.Info("Async load bundle BundleName : " + p);
+
+            // if (!File.Exists(p))
+            // {
+            //     Log.Error("Async load bundle not exist! BundleName : " + p);
+            //     return null;
+            // }
 
             assetBundle = await AssetBundleHelper.UnityLoadBundleAsync(p);
 


### PR DESCRIPTION
在Android端读取这个文件夹时，只能使用WWW进行异步读取，而在ios和pc上则可以使用File类及其他同步读取方式。