### PR TITLE
修改运行指南描述和小问题

### DIFF
--- a/Book/1.1运行指南.md
+++ b/Book/1.1运行指南.md
@@ -1,39 +1,42 @@
 # 运行步骤  
-##### 1.visual studio必须使用vs2019（更新到最新版）, VS2019需要勾选安装以下内容:
-a. .net 桌面开发  
-b. 去net core 官网下载安装 .net5 
-##### 2. master分支需要unity2020.3版
+1. visual studio必须使用vs2019（更新到最新版）, VS2019需要勾选安装以下内容:
+   - .net 桌面开发  
+   - 去net core官网下载安装 .net5 
 
-##### 3. 启动unity， 菜单 File->open project->open 选中ET/Unity文件夹，点击选择文件夹按钮。
+2. master分支需要unity2020.3版（用到了C#8的语法）
 
-##### 4.点击Unity菜单Assets->open C# project启动vs 编译（一定要编译，右键VS解决方案，全部编译）
+3. 启动Unity， 菜单 File -> Open Project... -> Open 选中ET/Unity文件夹，点击选择文件夹按钮。
 
-##### 5.用vs2019打开ET/Client-Server.sln 编译（一定要编译，右键VS解决方案，全部编译）
+4. 点击Unity菜单 Assets -> Open C# Project 启动vs编译
 
-##### 6.导表工具，编译完成后命令行进入Tools/ExcelExporter/Bin目录,执行dotnet ExcelExporter.dll
+5. 用vs2019打开 ET/Client-Server.sln 编译（**一定要全部工程编译，右键VS解决方案，全部编译**）
 
-##### 7.导出协议工具，编译完成后进入Tools/Proto2CS/Bin目录,执行dotnet  Proto2CS.dll
+6. 导表工具，编译完成后命令行进入 Tools/ExcelExporter/Bin 目录，执行 dotnet ExcelExporter.dll
 
+7. 导出协议工具，编译完成后进入 Tools/Proto2CS/Bin 目录，执行 dotnet  Proto2CS.dll
 
-# 测试状态同步demo， 帧同步demo已经删除，需要的话请看ET4.0
-##### 1. 打开Unity->tools菜单->命令行配置，重启server
-##### 2. Unity->tools菜单->打包工具，选择PC，勾选是否打包exe，点击开始打包，打出一个PC包在Release目录下
-##### 3. 启动unity菜单->tools->web资源服务器
-##### 4. 运行Unity 登录 进入大厅 进入场景
-##### 5. 运行PC包 登录 进入大厅
-##### 6. 点击鼠标右键即可移动人物
+# 测试状态同步demo
+
+>  帧同步demo已经删除，需要的话请看ET4.0分支
+
+1. 想修改配置就进入 Excel 目录修改对应的表格，做运行步骤的第6步，然后重新运行 Server.App工程来启动服务端。
+
+2. Unity->tools菜单->打包工具，选择PC，勾选是否打包exe，点击开始打包，打出一个PC包在Release目录下
+
+4. 运行Unity 登录 进入大厅 进入场景
+
+5. 运行PC包 登录 进入大厅
+
+6. 点击鼠标右键即可移动人物
 
 # 注意事项：
 
 一. 出错原因都是：  
-1.中文目录。  
-2.vs没有安装vs
-3.没安装 .net5
-4.没编译服务端
-5.VS要更新到最新版本  
 
-
-二. 目前ET使用ILRuntime模式无法单步调试，如果要切换到调试模式，删掉Unity的ILRuntime宏，重新编译即可  
-
-三. 使用Il2cpp打包需要在unity中加上ILRuntime宏  
+1. 中文目录。  
+2. vs没有安装vs相关组件
+3. 没安装 .net5
+4. 没编译服务端所有工程
+5. VS要更新到最新版本  
+6. Unity版本太低
 

--- a/Unity/Assets/Model/Core/Object/EventSystem.cs
+++ b/Unity/Assets/Model/Core/Object/EventSystem.cs
@@ -88,7 +88,7 @@ namespace ET
 
 		public void Add(Assembly assembly)
 		{
-			this.assemblies[assembly.ManifestModule.ScopeName] = assembly;
+			this.assemblies[$"{assembly.GetName().Name}.dll"] = assembly;
 			this.types.Clear();
 			foreach (Assembly value in this.assemblies.Values)
 			{

--- a/Unity/Assets/ModelView/Demo/Entry.cs
+++ b/Unity/Assets/ModelView/Demo/Entry.cs
@@ -15,7 +15,7 @@ namespace ET
 				
 				foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
 				{
-					string assemblyName = assembly.ManifestModule.Name;
+					string assemblyName = $"{assembly.GetName().Name}.dll";
 					if (!assemblyNames.Contains(assemblyName))
 					{
 						continue;

--- a/Unity/Assets/Mono/MonoBehaviour/Init.cs
+++ b/Unity/Assets/Mono/MonoBehaviour/Init.cs
@@ -26,7 +26,7 @@ namespace ET
 			Assembly modelAssembly = null;
 			foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
 			{
-				string assemblyName = assembly.ManifestModule.Name;
+				string assemblyName = $"{assembly.GetName().Name}.dll";
 				if (assemblyName != "Unity.ModelView.dll")
 				{
 					continue;

--- a/Unity/Packages/manifest.json
+++ b/Unity/Packages/manifest.json
@@ -4,6 +4,7 @@
     "com.unity.2d.tilemap": "1.0.0",
     "com.unity.assetbundlebrowser": "1.7.0",
     "com.unity.ide.rider": "2.0.7",
+    "com.unity.ide.visualstudio": "2.0.11",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.4.8",
     "com.unity.ugui": "1.0.0",

--- a/Unity/Packages/packages-lock.json
+++ b/Unity/Packages/packages-lock.json
@@ -35,6 +35,15 @@
       },
       "url": "https://packages.unity.cn"
     },
+    "com.unity.ide.visualstudio": {
+      "version": "2.0.11",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.9"
+      },
+      "url": "https://packages.unity.cn"
+    },
     "com.unity.test-framework": {
       "version": "1.1.24",
       "depth": 1,


### PR DESCRIPTION
1. 添加Visual Studio作为编译IDE时Unity必备的package。
2. 打il2cpp包需要修改assembly.ManifestModule获取方式。
3. 增减运行指南里的几个步骤。