### PR TITLE
Update 1.1运行指南.md

### DIFF
--- a/Book/1.1运行指南.md
+++ b/Book/1.1运行指南.md
@@ -1,27 +1,28 @@
 # 运行步骤  
 1. visual studio用户须知：
+   - VS 版本，必须使用2022及以上。注意，VS 2019 不支持 .Net 6，不能使用。
    - 需要安装"使用Unity的游戏开发"扩展。
    - 需要在"工具-选项-适用于Unity的工具-常规"里，把杂项里的禁止完整生成项目改为False，否则导致你Codes目录里的代码报错。
 
-2. 使用Rider2021.2.2（更新到最新版）, 需要安装以下内容:
+3. 使用Rider2021.2.2（更新到最新版）, 需要安装以下内容:
    - Rider的Unity插件  
    - 安装 .net6  
 
-2. master分支需要unity2020.3版（用到了C#8的语法）  
+4. master分支需要unity2020.3版（用到了C#8的语法）  
 
-3. 启动Unity， 菜单 File -> Open Project... -> Open 选中ET/Unity文件夹，点击选择文件夹按钮。  
+5. 启动Unity， 菜单 File -> Open Project... -> Open 选中ET/Unity文件夹，点击选择文件夹按钮。  
 
-4. 点击Unity菜单 Assets -> Open C# Project 启动vs  
+6. 点击Unity菜单 Assets -> Open C# Project 启动vs  
 
-5. 运行Unity菜单上的 Tools->BuildCode，这一步将编译客户端代码  
+7. 运行Unity菜单上的 Tools->BuildCode，这一步将编译客户端代码  
 
-6. 用Rider打开 ET/Client-Server.sln 编译（**一定要全部工程编译，右键VS解决方案，全部编译**）
+8. 用Rider打开 ET/Client-Server.sln 编译（**一定要全部工程编译，右键VS解决方案，全部编译**）
 
-7. 导表工具，编译完成后命令行进入 Bin 目录，执行 dotnet Tools.dll --AppType=ExcelExporter  
+9. 导表工具，编译完成后命令行进入 Bin 目录，执行 dotnet Tools.dll --AppType=ExcelExporter  
 
-8. 导出协议工具，编译完成后进入 Bin 目录，执行 dotnet Tools.dll --AppType=Proto2CS  
+10. 导出协议工具，编译完成后进入 Bin 目录，执行 dotnet Tools.dll --AppType=Proto2CS  
 
-9. Unity中双击Scenes目录中的Init场景，点击Play即可运行
+11. Unity中双击Scenes目录中的Init场景，点击Play即可运行
 # 测试状态同步demo
 1. 想修改配置就进入 Excel 目录修改对应的表格，做运行步骤的第6步，然后重新运行 Server.App工程来启动服务端。
 
@@ -38,9 +39,10 @@
 一. 出错原因都是：  
 
 1. 中文目录。  
-2. Rider没有安装相关组件
-3. 没安装 .net6
-4. 没编译服务端所有工程
-5. Rider要更新到最新版本  
-6. Unity版本太低
+2. VS 版本低
+3. Rider没有安装相关组件
+4. 没安装 .net6
+5. 没编译服务端所有工程
+6. Rider要更新到最新版本  
+7. Unity版本太低
 

--- a/Unity/Assets/StreamingAssets/BuildProjectNeedThisFolder.md
+++ b/Unity/Assets/StreamingAssets/BuildProjectNeedThisFolder.md
@@ -1,0 +1,1 @@
+BuildProjectNeedThisFolder


### PR DESCRIPTION
### 希望可以添加一部分关于IDE版本，更加的详细描述
两处添加：
* 行号3  - VS 版本，必须使用2022及以上。注意，VS 2019 不支持 .Net 6，不能使用。
* 行号42 2. VS 版本低