### PR TITLE
提前创建Define.BuildOutputDir目录

### DIFF
--- a/Unity/Assets/Editor/BuildEditor/BuildAssemblieEditor.cs
+++ b/Unity/Assets/Editor/BuildEditor/BuildAssemblieEditor.cs
@@ -102,12 +102,13 @@ namespace ET
                 }
             }
 
+            if (!Directory.Exists(Define.BuildOutputDir))
+                Directory.CreateDirectory(Define.BuildOutputDir);
+
             string dllPath = Path.Combine(Define.BuildOutputDir, $"{assemblyName}.dll");
             string pdbPath = Path.Combine(Define.BuildOutputDir, $"{assemblyName}.pdb");
             File.Delete(dllPath);
             File.Delete(pdbPath);
-
-            Directory.CreateDirectory(Define.BuildOutputDir);
 
             AssemblyBuilder assemblyBuilder = new AssemblyBuilder(dllPath, scripts.ToArray());
             


### PR DESCRIPTION
现在只开Unity不Open C# Project 按F5/F6编译代码会报错：
DirectoryNotFoundException: Could not find a part of the path 'G:\ProjectsGit\ET\Unity\Temp\Bin\Debug\Code.dll'.

在Delete旧dll和pdb之前创建这个目录就可以了