### PR TITLE
定位配置表具体哪一行出现了配置异常

### DIFF
--- a/Share/Tool/ExcelExporter/ExcelExporter.cs
+++ b/Share/Tool/ExcelExporter/ExcelExporter.cs
@@ -599,8 +599,33 @@ namespace ET
             foreach (string jsonPath in jsonPaths)
             {
                 string json = File.ReadAllText(jsonPath);
-                object deserialize = BsonSerializer.Deserialize(json, type);
-                final.Merge(deserialize);
+                try
+                {
+                    object deserialize = BsonSerializer.Deserialize(json, type);
+                    final.Merge(deserialize);
+                }
+                catch
+                {
+                    #region 为了定位该文件中具体那一行出现了异常
+                    List<string> list = new List<string>(json.Split('\n'));
+                    if (list.Count > 0)
+                        list.RemoveAt(0);
+                    if (list.Count > 0)
+                        list.RemoveAt(list.Count-1);
+                    foreach (string s in list)
+                    {
+                        try
+                        {
+                            BsonSerializer.Deserialize(s.Substring(0, s.Length-1), subType);
+                        }
+                        catch (Exception)
+                        {
+                            Log.Console($"json : {s}");
+                            throw;
+                        }
+                    }
+                    #endregion
+                }
             }
 
             string path = Path.Combine(dir, $"{protoName}Category.bytes");


### PR DESCRIPTION
原逻辑只能看到那个配置表那个字段有反序列化异常，不能知道哪一行出现了异常。现在当配置表出现异常就一行一行的反序列化，直到出现异常