### PR TITLE
修正: 数据库存储与查询使用的默认集合名字不一致, 导致查询失败的BUG

### DIFF
--- a/Unity/Assets/Scripts/Codes/Hotfix/Server/Module/DB/DBComponentSystem.cs
+++ b/Unity/Assets/Scripts/Codes/Hotfix/Server/Module/DB/DBComponentSystem.cs
@@ -19,7 +19,7 @@ namespace ET.Server
 
 	    private static IMongoCollection<T> GetCollection<T>(this DBComponent self, string collection = null)
 	    {
-		    return self.database.GetCollection<T>(collection ?? typeof (T).Name);
+		    return self.database.GetCollection<T>(collection ?? typeof (T).FullName);
 	    }
 
 	    private static IMongoCollection<Entity> GetCollection(this DBComponent self, string name)
@@ -114,7 +114,7 @@ namespace ET.Server
 	    {
 		    if (collection == null)
 		    {
-			    collection = typeof (T).Name;
+			    collection = typeof (T).FullName;
 		    }
 		    
 		    using (await CoroutineLockComponent.Instance.Wait(CoroutineLockType.DB, RandomGenerator.RandInt64() % DBComponent.TaskCount))


### PR DESCRIPTION
我记得前阵子好像改了一大堆Name为FullName, 是不是改漏了?