### PR TITLE
解决结构体内私有字段加了BsonElement还不能序列化的问题

### DIFF
--- a/Unity/Assets/Scripts/Core/Serialize/StructBsonSerialize.cs
+++ b/Unity/Assets/Scripts/Core/Serialize/StructBsonSerialize.cs
@@ -42,7 +42,7 @@ namespace ET
                     case BsonReaderState.Name:
                     {
                         string name = bsonReader.ReadName(Utf8NameDecoder.Instance);
-                        FieldInfo field = actualType.GetField(name);
+                        FieldInfo field = actualType.GetField(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
                         if (field != null)
                         {
                             object value = BsonSerializer.Deserialize(bsonReader, field.FieldType);


### PR DESCRIPTION
发现是序列化和反序列化时GetField的参数不一样