### PR TITLE
Bson序列化结构体时忽略没加BsonElement的私有字段

### DIFF
--- a/Unity/Assets/Scripts/Core/Serialize/StructBsonSerialize.cs
+++ b/Unity/Assets/Scripts/Core/Serialize/StructBsonSerialize.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace ET
 {
@@ -19,8 +20,13 @@ namespace ET
             FieldInfo[] fields = nominalType.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             foreach (FieldInfo field in fields)
             {
+                BsonElementAttribute bsonElement = field.GetCustomAttribute<BsonElementAttribute>();
+                if (bsonElement == null && !field.IsPublic)
+                {
+                    continue;
+                }
                 bsonWriter.WriteName(field.Name);
-                BsonSerializer.Serialize(bsonWriter, field.FieldType, field.GetValue(value));
+                BsonSerializer.Serialize(bsonWriter, field.FieldType, field.GetValue(value)); 
             }
 
             bsonWriter.WriteEndDocument();


### PR DESCRIPTION
上一次提交之前，Bson会把结构体所有私有字段都序列化，但反序列化时会忽略所有私有字段；
上一次提交会让反序列化把当初序列化出来的字段全读出来了，包括所有私有字段；
现在让Bson序列化结构体时忽略没加BsonElement的私有字段，这会减小序列化文件大小，并且反序列化表现跟上一次提交之前一致。