### PR TITLE
日志重定向之前的思路就有问题，肯定会有个倒霉蛋碰到行号恰好跟跳过的那三个文件之一行号一样的情况，这次避免了这种情况

### DIFF
--- a/Unity/Assets/Scripts/Editor/LogRedirection/LogRedirection.cs
+++ b/Unity/Assets/Scripts/Editor/LogRedirection/LogRedirection.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -20,50 +21,25 @@ namespace ET
             {
                 return false;
             }
-            string stackTrace = GetStackTrace();
-            if (string.IsNullOrEmpty(stackTrace))
-            {
-                return false;
-            }
-
-            // 编译错误不重定向
-            Match compileErrorMatch = Regex.Match(stackTrace, @"(.*?)\(([0-9]+),([0-9]+)\): error");
-            if (compileErrorMatch.Success)
-            {
-                return false;
-            }
 
             Regex logFileRegex = new(@"((Log\.cs)|(UnityLogger\.cs)|(YooLogger\.cs))");
-            Match stackLineMatch = Regex.Match(stackTrace, $@"\(at (.+):{line}\)");
-            if (!stackLineMatch.Success)
+            string codePath = AssetDatabase.GetAssetPath(instanceID);
+            if (logFileRegex.IsMatch(codePath))
             {
-                // 没堆栈 不重定向
-                return false;
-            }
-            if (stackLineMatch.Success)
-            {
-                string codePath = stackLineMatch.Groups[1].Value;
-                if (!logFileRegex.IsMatch(codePath))
+                Match stackLineMatch = Regex.Match(GetStackTrace(), @"\(at (.+):([0-9]+)\)");
+                while (stackLineMatch.Success)
                 {
-                    // 不是相关文件不重定向
-                    return false;
+                    codePath = stackLineMatch.Groups[1].Value;
+                    if (!logFileRegex.IsMatch(codePath))
+                    {
+                        int matchLine = int.Parse(stackLineMatch.Groups[2].Value);
+                        OpenIDE(codePath, matchLine);
+                        return true;
+                    }
+                    stackLineMatch = stackLineMatch.NextMatch();
                 }
             }
-
-            // 重定向
-            stackLineMatch = Regex.Match(stackTrace, @"\(at (.+):([0-9]+)\)");
-            while (stackLineMatch.Success)
-            {
-                string codePath = stackLineMatch.Groups[1].Value;
-                if (!logFileRegex.IsMatch(codePath))
-                {
-                    int matchLine = int.Parse(stackLineMatch.Groups[2].Value);
-                    OpenIDE(codePath, matchLine);
-                    return true;
-                }
-                stackLineMatch = stackLineMatch.NextMatch();
-            }
-
+            
             return false;
         }
 


### PR DESCRIPTION
但是现在这么搞的话，如果把Log.cs放到Assests文件夹外面，重定向就失效了