### PR TITLE
解决AOI自己进入自己视野数据问题。

### DIFF
--- a/Unity/Assets/Scripts/Hotfix/Server/Module/AOI/AOIEntitySystem.cs
+++ b/Unity/Assets/Scripts/Hotfix/Server/Module/AOI/AOIEntitySystem.cs
@@ -54,10 +54,11 @@ namespace ET.Server
             cell.SubsEnterEntities.Add(self.Id, self);
             foreach (KeyValuePair<long, AOIEntity> kv in cell.AOIUnits)
             {
-                if (kv.Key == self.Id)
+                // EnterSight 里已经判断过id 了，这里无需再判断
+                /*if (kv.Key == self.Id)
                 {
                     continue;
-                }
+                }*/
 
                 self.EnterSight(kv.Value);
             }
@@ -78,10 +79,11 @@ namespace ET.Server
         {
             foreach (KeyValuePair<long, AOIEntity> kv in cell.AOIUnits)
             {
-                if (kv.Key == self.Id)
+                // LeaveSight 里已经判断过id 了，这里无需再判断
+                /*if (kv.Key == self.Id)
                 {
                     continue;
-                }
+                }*/
 
                 self.LeaveSight(kv.Value);
             }
@@ -92,6 +94,12 @@ namespace ET.Server
         // enter进入self视野
         public static void EnterSight(this AOIEntity self, AOIEntity enter)
         {
+            //需要判断id，避免self自己进入自己的视野
+            if (self.Id == enter.Id)
+            {
+                return;
+            }
+            
             // 有可能之前在Enter，后来出了Enter还在LeaveCell，这样仍然没有删除，继续进来Enter，这种情况不需要处理
             if (self.SeeUnits.ContainsKey(enter.Id))
             {

--- a/Unity/Assets/Scripts/Hotfix/Server/Module/AOI/AOIManagerComponentSystem.cs
+++ b/Unity/Assets/Scripts/Hotfix/Server/Module/AOI/AOIManagerComponentSystem.cs
@@ -51,7 +51,8 @@ namespace ET.Server
                 return;
             }
 
-            Fiber fiber = self.Fiber();
+            // 这里fiber没用到，所以先注释了
+            // Fiber fiber = self.Fiber();
             // 通知订阅该Cell Leave的Unit
             aoiEntity.Cell.Remove(aoiEntity);
             foreach (KeyValuePair<long, AOIEntity> kv in aoiEntity.Cell.SubsLeaveEntities)


### PR DESCRIPTION
调试的时候发现在AOIManagerComponentSystem Add 方法调用时，出现了自己进入自己视野的情况，主要原因是43行这里  kv.Value.EnterSight(aoiEntity); 之前没有做自身id判断导致。所以优化代码，id判断统一放在 EnterSight 和 LeaveSight 里，避免调用时忘记判断自身id这种情况。