### PR TITLE
1：编译Debug的Dll由GlobalConfig的BuildType决定

### DIFF
--- a/Unity/Assets/Scripts/Editor/Assembly/AssemblyTool.cs
+++ b/Unity/Assets/Scripts/Editor/Assembly/AssemblyTool.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Threading;
 using UnityEditor;
@@ -30,13 +29,29 @@ namespace ET
             return BuildTarget.StandaloneWindows;
         }
 
+        public static void RefreshCodeMode(CodeMode codeMode)
+        {
+            switch (codeMode)
+            {
+                case CodeMode.Client:
+                    Enable_UNITY_CLIENT();
+                    break;
+                case CodeMode.Server:
+                    Enable_UNITY_SERVER();
+                    break;
+                case CodeMode.ClientServer:
+                    Enable_UNITY_CLIENTSERVER();
+                    break;
+            }
+        }
+
         public static void DoCompile()
         {
-            BuildTarget target = EditorUserBuildSettings.activeBuildTarget;
-            ScriptCompilationOptions options = EditorUserBuildSettings.development
+            GlobalConfig globalConfig = Resources.Load<GlobalConfig>("GlobalConfig");
+            ScriptCompilationOptions options = globalConfig.BuildType == BuildType.Debug
                     ? ScriptCompilationOptions.DevelopmentBuild
                     : ScriptCompilationOptions.None;
-            CompileDlls(target, options);
+            CompileDlls(EditorUserBuildSettings.activeBuildTarget, options);
             CopyHotUpdateDlls();
         }
 
@@ -47,6 +62,8 @@ namespace ET
 
         public static void CompileDlls(BuildTarget target, ScriptCompilationOptions options = ScriptCompilationOptions.None)
         {
+            //强制刷新一下，防止关闭auto refresh，编译出老代码
+            AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate);
             SynchronizationContext lastSynchronizationContext = null;
             if (Application.isPlaying) //运行时编译需要UnitySynchronizationContext
             {

--- a/Unity/Assets/Scripts/Editor/Assembly/AssemblyTool.cs
+++ b/Unity/Assets/Scripts/Editor/Assembly/AssemblyTool.cs
@@ -70,6 +70,10 @@ namespace ET
                 lastSynchronizationContext = SynchronizationContext.Current;
                 SynchronizationContext.SetSynchronizationContext(AssemblyEditor.UnitySynchronizationContext);
             }
+            else
+            {
+                SynchronizationContext.SetSynchronizationContext(AssemblyEditor.UnitySynchronizationContext);
+            }
             try
             {
                 Directory.CreateDirectory(Define.BuildOutputDir);
@@ -87,7 +91,7 @@ namespace ET
             }
             finally
             {
-                if (lastSynchronizationContext != null)
+                if (Application.isPlaying && lastSynchronizationContext != null)
                 {
                     SynchronizationContext.SetSynchronizationContext(lastSynchronizationContext);
                 }

--- a/Unity/Assets/Scripts/Editor/AssetPostProcessor/OnGenerateCSProjectProcessor.cs
+++ b/Unity/Assets/Scripts/Editor/AssetPostProcessor/OnGenerateCSProjectProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Xml;
 using UnityEditor;
+using UnityEngine;
 
 namespace ET
 {
@@ -11,6 +12,10 @@ namespace ET
         /// </summary>
         public static string OnGeneratedCSProject(string path, string content)
         {
+            //刷新一下CodeMode，防止某些本地修改CodeMode测试后，使用svn更新，被改名的Ignore.asmdef被还原的问题
+            GlobalConfig globalConfig = Resources.Load<GlobalConfig>("GlobalConfig");
+            AssemblyTool.RefreshCodeMode(globalConfig.CodeMode);
+
             if (path.EndsWith("Unity.Core.csproj"))
             {
                 content = GenerateCustomProject(content);

--- a/Unity/Assets/Scripts/Editor/BuildEditor/BuildEditor.cs
+++ b/Unity/Assets/Scripts/Editor/BuildEditor/BuildEditor.cs
@@ -134,18 +134,7 @@ namespace ET
                 this.globalConfig.CodeMode = codeMode;
                 EditorUtility.SetDirty(this.globalConfig);
                 AssetDatabase.SaveAssets();
-                switch (codeMode)
-                {
-                    case CodeMode.Client:
-                        AssemblyTool.Enable_UNITY_CLIENT();
-                        break;
-                    case CodeMode.Server:
-                        AssemblyTool.Enable_UNITY_SERVER();
-                        break;
-                    case CodeMode.ClientServer:
-                        AssemblyTool.Enable_UNITY_CLIENTSERVER();
-                        break;
-                }
+                AssemblyTool.RefreshCodeMode(codeMode);
             }
 
             EPlayMode ePlayMode = (EPlayMode)EditorGUILayout.EnumPopup("EPlayMode: ", this.globalConfig.EPlayMode);

--- a/Unity/Assets/Scripts/Editor/GlobalConfigEditor/GlobalConfigEditor.cs
+++ b/Unity/Assets/Scripts/Editor/GlobalConfigEditor/GlobalConfigEditor.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEditor;
 
 namespace ET
@@ -22,18 +21,7 @@ namespace ET
             {
                 m_CurCodeMode = globalConfig.CodeMode;
                 this.serializedObject.Update();
-                switch (globalConfig.CodeMode)
-                {
-                    case CodeMode.Client:
-                        AssemblyTool.Enable_UNITY_CLIENT();
-                        break;
-                    case CodeMode.Server:
-                        AssemblyTool.Enable_UNITY_SERVER();
-                        break;
-                    case CodeMode.ClientServer:
-                        AssemblyTool.Enable_UNITY_CLIENTSERVER();
-                        break;
-                }
+                AssemblyTool.RefreshCodeMode(globalConfig.CodeMode);
             }
         }
     }


### PR DESCRIPTION
2：Unity生成csproj时刷新一次CodeMode目录结构，防止本地更改CodeMode测试后svn更新还原Ignore.asmdef的情况