### PR TITLE
修复一个Linux下Watcher启动子进程一段时间后进程锁死的问题

### DIFF
--- a/Unity/Assets/Scripts/Core/Helper/ProcessHelper.cs
+++ b/Unity/Assets/Scripts/Core/Helper/ProcessHelper.cs
@@ -13,13 +13,11 @@ namespace ET
             //Log.Debug($"Process Run exe:{exe} ,arguments:{arguments} ,workingDirectory:{workingDirectory}");
             try
             {
-                bool redirectStandardOutput = true;
-                bool redirectStandardError = true;
+                bool redirectStandardOutput = false;
+                bool redirectStandardError = false;
                 bool useShellExecute = false;
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    redirectStandardOutput = false;
-                    redirectStandardError = false;
                     useShellExecute = true;
                 }
                 


### PR DESCRIPTION
Linux下Watcher启动，跑压力一小段时间后子进程的主线程死锁，查到是Watcher默认设置了IO重定位（但默认没读取IO重定位）导致一段时间后卡死在Log函数。