### PR TITLE
NetworkHelper 增加几种判断情况

### DIFF
--- a/Unity/Assets/Scripts/Core/Helper/NetworkHelper.cs
+++ b/Unity/Assets/Scripts/Core/Helper/NetworkHelper.cs
@@ -14,7 +14,9 @@ namespace ET
 			List<string> list = new List<string>();
 			foreach (NetworkInterface networkInterface in NetworkInterface.GetAllNetworkInterfaces())
 			{
-				if (networkInterface.NetworkInterfaceType != NetworkInterfaceType.Ethernet)
+				if (networkInterface.NetworkInterfaceType != NetworkInterfaceType.Ethernet 
+				    && networkInterface.NetworkInterfaceType != NetworkInterfaceType.Wireless80211
+				    && networkInterface.NetworkInterfaceType != NetworkInterfaceType.Loopback)
 				{
 					continue;
 				}


### PR DESCRIPTION
Wireless80211 是笔记本的无线网络
Loopback 是 127.0.0.1
不加上这两种类型，本地测试活着使用笔记本无线网络测试的时候，Watcher进程拉不起来