### PR TITLE
感觉这里应该读 RouterManager 所在机器的外网IP

### DIFF
--- a/Unity/Assets/Scripts/Hotfix/Server/Module/Router/FiberInit_RouterManager.cs
+++ b/Unity/Assets/Scripts/Hotfix/Server/Module/Router/FiberInit_RouterManager.cs
@@ -9,7 +9,9 @@ namespace ET.Server
         {
             Scene root = fiberInit.Fiber.Root;
             StartSceneConfig startSceneConfig = StartSceneConfigCategory.Instance.Get((int)root.Id);
-            root.AddComponent<HttpComponent, string>($"http://*:{startSceneConfig.Port}/");
+            string httpAddress = $"http://{startSceneConfig.StartProcessConfig.OuterIP}:{startSceneConfig.Port}/";
+            Log.Console("RouterManager 地址: " + httpAddress);
+            root.AddComponent<HttpComponent, string>(httpAddress);
 
             await ETTask.CompletedTask;
         }


### PR DESCRIPTION
顺便增加了一个 Log.Console 打印出来当前 RouterManager 监听的HTTP地址，方便定位查看