### PR TITLE
Entity未赋值IScene时 序列化到会导致数据丢失

### DIFF
--- a/Unity/Assets/Scripts/Core/Entity/Entity.cs
+++ b/Unity/Assets/Scripts/Core/Entity/Entity.cs
@@ -941,6 +941,8 @@ namespace ET
         {
             EntitySystemSingleton.Instance.Serialize(this);
             
+            if (!this.IsCreated) return;
+
             this.componentsDB?.Clear();
             if (this.components != null && this.components.Count != 0)
             {


### PR DESCRIPTION
缓存服中Entity从数据库读出未赋值IScene，component 和 children 并不会被赋值。如果此时对其进行序列化会调用Entity的BeginInit 清空componentsDB，childrenDB，导致数据丢失。