### PR TITLE
优化消息赋值的便捷性

### DIFF
--- a/Unity/Assets/Scripts/Model/Generate/Client/Message/ClientMessage_C_1000.cs
+++ b/Unity/Assets/Scripts/Model/Generate/Client/Message/ClientMessage_C_1000.cs
@@ -8,11 +8,6 @@ namespace ET
     [ResponseType(nameof(NetClient2Main_Login))]
     public partial class Main2NetClient_Login : MessageObject, IRequest
     {
-        public static Main2NetClient_Login Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Main2NetClient_Login), isFromPool) as Main2NetClient_Login;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -30,6 +25,33 @@ namespace ET
         /// </summary>
         [MemoryPackOrder(3)]
         public string Password { get; set; }
+
+        /// <summary>
+        /// Create Main2NetClient_Login
+        /// </summary>
+        /// <param name="ownerFiberId">OwnerFiberId</param>
+        /// <param name="account">账号</param>
+        /// <param name="password">密码</param>
+        /// <param name="isFromPool"></param>
+        public static Main2NetClient_Login Create(int ownerFiberId = default, string account = default, string password = default, bool isFromPool = false)
+        {
+            Main2NetClient_Login msg = ObjectPool.Instance.Fetch(typeof(Main2NetClient_Login), isFromPool) as Main2NetClient_Login;
+            msg.Set(ownerFiberId, account, password);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set Main2NetClient_Login
+        /// </summary>
+        /// <param name="ownerFiberId">OwnerFiberId</param>
+        /// <param name="account">账号</param>
+        /// <param name="password">密码</param>
+        public void Set(int ownerFiberId = default, string account = default, string password = default)
+        {
+            this.OwnerFiberId = ownerFiberId;
+            this.Account = account;
+            this.Password = password;
+        }
 
         public override void Dispose()
         {
@@ -51,11 +73,6 @@ namespace ET
     [Message(ClientMessage.NetClient2Main_Login)]
     public partial class NetClient2Main_Login : MessageObject, IResponse
     {
-        public static NetClient2Main_Login Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(NetClient2Main_Login), isFromPool) as NetClient2Main_Login;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -67,6 +84,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public long PlayerId { get; set; }
+
+        public static NetClient2Main_Login Create(int error = default, string message = default, long playerId = default, bool isFromPool = false)
+        {
+            NetClient2Main_Login msg = ObjectPool.Instance.Fetch(typeof(NetClient2Main_Login), isFromPool) as NetClient2Main_Login;
+            msg.Set(error, message, playerId);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, long playerId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.PlayerId = playerId;
+        }
 
         public override void Dispose()
         {

--- a/Unity/Assets/Scripts/Model/Generate/Client/Message/LockStepOuter_C_11001.cs
+++ b/Unity/Assets/Scripts/Model/Generate/Client/Message/LockStepOuter_C_11001.cs
@@ -8,13 +8,13 @@ namespace ET
     [ResponseType(nameof(G2C_Match))]
     public partial class C2G_Match : MessageObject, ISessionRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2G_Match Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2G_Match), isFromPool) as C2G_Match;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -33,11 +33,6 @@ namespace ET
     [Message(LockStepOuter.G2C_Match)]
     public partial class G2C_Match : MessageObject, ISessionResponse
     {
-        public static G2C_Match Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_Match), isFromPool) as G2C_Match;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -46,6 +41,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static G2C_Match Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            G2C_Match msg = ObjectPool.Instance.Fetch(typeof(G2C_Match), isFromPool) as G2C_Match;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -69,11 +77,6 @@ namespace ET
     [Message(LockStepOuter.Match2G_NotifyMatchSuccess)]
     public partial class Match2G_NotifyMatchSuccess : MessageObject, IMessage
     {
-        public static Match2G_NotifyMatchSuccess Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Match2G_NotifyMatchSuccess), isFromPool) as Match2G_NotifyMatchSuccess;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -82,6 +85,30 @@ namespace ET
         /// </summary>
         [MemoryPackOrder(1)]
         public ActorId ActorId { get; set; }
+
+        /// <summary>
+        /// Create Match2G_NotifyMatchSuccess
+        /// </summary>
+        /// <param name="rpcId">RpcId</param>
+        /// <param name="actorId">房间的ActorId</param>
+        /// <param name="isFromPool"></param>
+        public static Match2G_NotifyMatchSuccess Create(int rpcId = default, ActorId actorId = default, bool isFromPool = false)
+        {
+            Match2G_NotifyMatchSuccess msg = ObjectPool.Instance.Fetch(typeof(Match2G_NotifyMatchSuccess), isFromPool) as Match2G_NotifyMatchSuccess;
+            msg.Set(rpcId, actorId);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set Match2G_NotifyMatchSuccess
+        /// </summary>
+        /// <param name="rpcId">RpcId</param>
+        /// <param name="actorId">房间的ActorId</param>
+        public void Set(int rpcId = default, ActorId actorId = default)
+        {
+            this.RpcId = rpcId;
+            this.ActorId = actorId;
+        }
 
         public override void Dispose()
         {
@@ -104,13 +131,20 @@ namespace ET
     [Message(LockStepOuter.C2Room_ChangeSceneFinish)]
     public partial class C2Room_ChangeSceneFinish : MessageObject, IRoomMessage
     {
-        public static C2Room_ChangeSceneFinish Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2Room_ChangeSceneFinish), isFromPool) as C2Room_ChangeSceneFinish;
-        }
-
         [MemoryPackOrder(0)]
         public long PlayerId { get; set; }
+
+        public static C2Room_ChangeSceneFinish Create(long playerId = default, bool isFromPool = false)
+        {
+            C2Room_ChangeSceneFinish msg = ObjectPool.Instance.Fetch(typeof(C2Room_ChangeSceneFinish), isFromPool) as C2Room_ChangeSceneFinish;
+            msg.Set(playerId);
+            return msg;
+        }
+
+        public void Set(long playerId = default)
+        {
+            this.PlayerId = playerId;
+        }
 
         public override void Dispose()
         {
@@ -129,11 +163,6 @@ namespace ET
     [Message(LockStepOuter.LockStepUnitInfo)]
     public partial class LockStepUnitInfo : MessageObject
     {
-        public static LockStepUnitInfo Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(LockStepUnitInfo), isFromPool) as LockStepUnitInfo;
-        }
-
         [MemoryPackOrder(0)]
         public long PlayerId { get; set; }
 
@@ -142,6 +171,20 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public TrueSync.TSQuaternion Rotation { get; set; }
+
+        public static LockStepUnitInfo Create(long playerId = default, TrueSync.TSVector position = default, TrueSync.TSQuaternion rotation = default, bool isFromPool = false)
+        {
+            LockStepUnitInfo msg = ObjectPool.Instance.Fetch(typeof(LockStepUnitInfo), isFromPool) as LockStepUnitInfo;
+            msg.Set(playerId, position, rotation);
+            return msg;
+        }
+
+        public void Set(long playerId = default, TrueSync.TSVector position = default, TrueSync.TSQuaternion rotation = default)
+        {
+            this.PlayerId = playerId;
+            this.Position = position;
+            this.Rotation = rotation;
+        }
 
         public override void Dispose()
         {
@@ -165,16 +208,23 @@ namespace ET
     [Message(LockStepOuter.Room2C_Start)]
     public partial class Room2C_Start : MessageObject, IMessage
     {
-        public static Room2C_Start Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Room2C_Start), isFromPool) as Room2C_Start;
-        }
-
         [MemoryPackOrder(0)]
         public long StartTime { get; set; }
 
         [MemoryPackOrder(1)]
         public List<LockStepUnitInfo> UnitInfo { get; set; } = new();
+
+        public static Room2C_Start Create(long startTime = default, bool isFromPool = false)
+        {
+            Room2C_Start msg = ObjectPool.Instance.Fetch(typeof(Room2C_Start), isFromPool) as Room2C_Start;
+            msg.Set(startTime);
+            return msg;
+        }
+
+        public void Set(long startTime = default)
+        {
+            this.StartTime = startTime;
+        }
 
         public override void Dispose()
         {
@@ -194,11 +244,6 @@ namespace ET
     [Message(LockStepOuter.FrameMessage)]
     public partial class FrameMessage : MessageObject, IMessage
     {
-        public static FrameMessage Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(FrameMessage), isFromPool) as FrameMessage;
-        }
-
         [MemoryPackOrder(0)]
         public int Frame { get; set; }
 
@@ -207,6 +252,20 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public LSInput Input { get; set; }
+
+        public static FrameMessage Create(int frame = default, long playerId = default, LSInput input = default, bool isFromPool = false)
+        {
+            FrameMessage msg = ObjectPool.Instance.Fetch(typeof(FrameMessage), isFromPool) as FrameMessage;
+            msg.Set(frame, playerId, input);
+            return msg;
+        }
+
+        public void Set(int frame = default, long playerId = default, LSInput input = default)
+        {
+            this.Frame = frame;
+            this.PlayerId = playerId;
+            this.Input = input;
+        }
 
         public override void Dispose()
         {
@@ -227,14 +286,15 @@ namespace ET
     [Message(LockStepOuter.OneFrameInputs)]
     public partial class OneFrameInputs : MessageObject, IMessage
     {
+        [MongoDB.Bson.Serialization.Attributes.BsonDictionaryOptions(MongoDB.Bson.Serialization.Options.DictionaryRepresentation.ArrayOfArrays)]
+        [MemoryPackOrder(1)]
+        public Dictionary<long, LSInput> Inputs { get; set; } = new();
+
         public static OneFrameInputs Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(OneFrameInputs), isFromPool) as OneFrameInputs;
         }
 
-        [MongoDB.Bson.Serialization.Attributes.BsonDictionaryOptions(MongoDB.Bson.Serialization.Options.DictionaryRepresentation.ArrayOfArrays)]
-        [MemoryPackOrder(1)]
-        public Dictionary<long, LSInput> Inputs { get; set; } = new();
         public override void Dispose()
         {
             if (!this.IsFromPool)
@@ -252,13 +312,20 @@ namespace ET
     [Message(LockStepOuter.Room2C_AdjustUpdateTime)]
     public partial class Room2C_AdjustUpdateTime : MessageObject, IMessage
     {
-        public static Room2C_AdjustUpdateTime Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Room2C_AdjustUpdateTime), isFromPool) as Room2C_AdjustUpdateTime;
-        }
-
         [MemoryPackOrder(0)]
         public int DiffTime { get; set; }
+
+        public static Room2C_AdjustUpdateTime Create(int diffTime = default, bool isFromPool = false)
+        {
+            Room2C_AdjustUpdateTime msg = ObjectPool.Instance.Fetch(typeof(Room2C_AdjustUpdateTime), isFromPool) as Room2C_AdjustUpdateTime;
+            msg.Set(diffTime);
+            return msg;
+        }
+
+        public void Set(int diffTime = default)
+        {
+            this.DiffTime = diffTime;
+        }
 
         public override void Dispose()
         {
@@ -277,11 +344,6 @@ namespace ET
     [Message(LockStepOuter.C2Room_CheckHash)]
     public partial class C2Room_CheckHash : MessageObject, IRoomMessage
     {
-        public static C2Room_CheckHash Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2Room_CheckHash), isFromPool) as C2Room_CheckHash;
-        }
-
         [MemoryPackOrder(0)]
         public long PlayerId { get; set; }
 
@@ -290,6 +352,20 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public long Hash { get; set; }
+
+        public static C2Room_CheckHash Create(long playerId = default, int frame = default, long hash = default, bool isFromPool = false)
+        {
+            C2Room_CheckHash msg = ObjectPool.Instance.Fetch(typeof(C2Room_CheckHash), isFromPool) as C2Room_CheckHash;
+            msg.Set(playerId, frame, hash);
+            return msg;
+        }
+
+        public void Set(long playerId = default, int frame = default, long hash = default)
+        {
+            this.PlayerId = playerId;
+            this.Frame = frame;
+            this.Hash = hash;
+        }
 
         public override void Dispose()
         {
@@ -310,16 +386,24 @@ namespace ET
     [Message(LockStepOuter.Room2C_CheckHashFail)]
     public partial class Room2C_CheckHashFail : MessageObject, IMessage
     {
-        public static Room2C_CheckHashFail Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Room2C_CheckHashFail), isFromPool) as Room2C_CheckHashFail;
-        }
-
         [MemoryPackOrder(0)]
         public int Frame { get; set; }
 
         [MemoryPackOrder(1)]
         public byte[] LSWorldBytes { get; set; }
+
+        public static Room2C_CheckHashFail Create(int frame = default, byte[] lSWorldBytes = default, bool isFromPool = false)
+        {
+            Room2C_CheckHashFail msg = ObjectPool.Instance.Fetch(typeof(Room2C_CheckHashFail), isFromPool) as Room2C_CheckHashFail;
+            msg.Set(frame, lSWorldBytes);
+            return msg;
+        }
+
+        public void Set(int frame = default, byte[] lSWorldBytes = default)
+        {
+            this.Frame = frame;
+            this.LSWorldBytes = lSWorldBytes;
+        }
 
         public override void Dispose()
         {
@@ -339,11 +423,6 @@ namespace ET
     [Message(LockStepOuter.G2C_Reconnect)]
     public partial class G2C_Reconnect : MessageObject, IMessage
     {
-        public static G2C_Reconnect Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_Reconnect), isFromPool) as G2C_Reconnect;
-        }
-
         [MemoryPackOrder(0)]
         public long StartTime { get; set; }
 
@@ -352,6 +431,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public int Frame { get; set; }
+
+        public static G2C_Reconnect Create(long startTime = default, int frame = default, bool isFromPool = false)
+        {
+            G2C_Reconnect msg = ObjectPool.Instance.Fetch(typeof(G2C_Reconnect), isFromPool) as G2C_Reconnect;
+            msg.Set(startTime, frame);
+            return msg;
+        }
+
+        public void Set(long startTime = default, int frame = default)
+        {
+            this.StartTime = startTime;
+            this.Frame = frame;
+        }
 
         public override void Dispose()
         {

--- a/Unity/Assets/Scripts/Model/Generate/Client/Message/OuterMessage_C_10001.cs
+++ b/Unity/Assets/Scripts/Model/Generate/Client/Message/OuterMessage_C_10001.cs
@@ -7,16 +7,16 @@ namespace ET
     [Message(OuterMessage.HttpGetRouterResponse)]
     public partial class HttpGetRouterResponse : MessageObject
     {
-        public static HttpGetRouterResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(HttpGetRouterResponse), isFromPool) as HttpGetRouterResponse;
-        }
-
         [MemoryPackOrder(0)]
         public List<string> Realms { get; set; } = new();
 
         [MemoryPackOrder(1)]
         public List<string> Routers { get; set; } = new();
+
+        public static HttpGetRouterResponse Create(bool isFromPool = false)
+        {
+            return ObjectPool.Instance.Fetch(typeof(HttpGetRouterResponse), isFromPool) as HttpGetRouterResponse;
+        }
 
         public override void Dispose()
         {
@@ -36,16 +36,24 @@ namespace ET
     [Message(OuterMessage.RouterSync)]
     public partial class RouterSync : MessageObject
     {
-        public static RouterSync Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(RouterSync), isFromPool) as RouterSync;
-        }
-
         [MemoryPackOrder(0)]
         public uint ConnectId { get; set; }
 
         [MemoryPackOrder(1)]
         public string Address { get; set; }
+
+        public static RouterSync Create(uint connectId = default, string address = default, bool isFromPool = false)
+        {
+            RouterSync msg = ObjectPool.Instance.Fetch(typeof(RouterSync), isFromPool) as RouterSync;
+            msg.Set(connectId, address);
+            return msg;
+        }
+
+        public void Set(uint connectId = default, string address = default)
+        {
+            this.ConnectId = connectId;
+            this.Address = address;
+        }
 
         public override void Dispose()
         {
@@ -66,16 +74,23 @@ namespace ET
     [ResponseType(nameof(M2C_TestResponse))]
     public partial class C2M_TestRequest : MessageObject, ILocationRequest
     {
-        public static C2M_TestRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_TestRequest), isFromPool) as C2M_TestRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public string request { get; set; }
+
+        public static C2M_TestRequest Create(string request = default, bool isFromPool = false)
+        {
+            C2M_TestRequest msg = ObjectPool.Instance.Fetch(typeof(C2M_TestRequest), isFromPool) as C2M_TestRequest;
+            msg.Set(request);
+            return msg;
+        }
+
+        public void Set(string request = default)
+        {
+            this.request = request;
+        }
 
         public override void Dispose()
         {
@@ -95,11 +110,6 @@ namespace ET
     [Message(OuterMessage.M2C_TestResponse)]
     public partial class M2C_TestResponse : MessageObject, IResponse
     {
-        public static M2C_TestResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_TestResponse), isFromPool) as M2C_TestResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -111,6 +121,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public string response { get; set; }
+
+        public static M2C_TestResponse Create(int error = default, string message = default, string response = default, bool isFromPool = false)
+        {
+            M2C_TestResponse msg = ObjectPool.Instance.Fetch(typeof(M2C_TestResponse), isFromPool) as M2C_TestResponse;
+            msg.Set(error, message, response);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, string response = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.response = response;
+        }
 
         public override void Dispose()
         {
@@ -133,13 +157,13 @@ namespace ET
     [ResponseType(nameof(G2C_EnterMap))]
     public partial class C2G_EnterMap : MessageObject, ISessionRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2G_EnterMap Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2G_EnterMap), isFromPool) as C2G_EnterMap;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -158,11 +182,6 @@ namespace ET
     [Message(OuterMessage.G2C_EnterMap)]
     public partial class G2C_EnterMap : MessageObject, ISessionResponse
     {
-        public static G2C_EnterMap Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_EnterMap), isFromPool) as G2C_EnterMap;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -177,6 +196,33 @@ namespace ET
         /// </summary>
         [MemoryPackOrder(3)]
         public long MyId { get; set; }
+
+        /// <summary>
+        /// Create G2C_EnterMap
+        /// </summary>
+        /// <param name="error">错误码</param>
+        /// <param name="message">错误消息</param>
+        /// <param name="myId">自己的UnitId</param>
+        /// <param name="isFromPool"></param>
+        public static G2C_EnterMap Create(int error = default, string message = default, long myId = default, bool isFromPool = false)
+        {
+            G2C_EnterMap msg = ObjectPool.Instance.Fetch(typeof(G2C_EnterMap), isFromPool) as G2C_EnterMap;
+            msg.Set(error, message, myId);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set G2C_EnterMap
+        /// </summary>
+        /// <param name="error">错误码</param>
+        /// <param name="message">错误消息</param>
+        /// <param name="myId">自己的UnitId</param>
+        public void Set(int error = default, string message = default, long myId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.MyId = myId;
+        }
 
         public override void Dispose()
         {
@@ -198,11 +244,6 @@ namespace ET
     [Message(OuterMessage.MoveInfo)]
     public partial class MoveInfo : MessageObject
     {
-        public static MoveInfo Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(MoveInfo), isFromPool) as MoveInfo;
-        }
-
         [MemoryPackOrder(0)]
         public List<Unity.Mathematics.float3> Points { get; set; } = new();
 
@@ -211,6 +252,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public int TurnSpeed { get; set; }
+
+        public static MoveInfo Create(Unity.Mathematics.quaternion rotation = default, int turnSpeed = default, bool isFromPool = false)
+        {
+            MoveInfo msg = ObjectPool.Instance.Fetch(typeof(MoveInfo), isFromPool) as MoveInfo;
+            msg.Set(rotation, turnSpeed);
+            return msg;
+        }
+
+        public void Set(Unity.Mathematics.quaternion rotation = default, int turnSpeed = default)
+        {
+            this.Rotation = rotation;
+            this.TurnSpeed = turnSpeed;
+        }
 
         public override void Dispose()
         {
@@ -231,11 +285,6 @@ namespace ET
     [Message(OuterMessage.UnitInfo)]
     public partial class UnitInfo : MessageObject
     {
-        public static UnitInfo Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(UnitInfo), isFromPool) as UnitInfo;
-        }
-
         [MemoryPackOrder(0)]
         public long UnitId { get; set; }
 
@@ -254,8 +303,26 @@ namespace ET
         [MongoDB.Bson.Serialization.Attributes.BsonDictionaryOptions(MongoDB.Bson.Serialization.Options.DictionaryRepresentation.ArrayOfArrays)]
         [MemoryPackOrder(5)]
         public Dictionary<int, long> KV { get; set; } = new();
+
         [MemoryPackOrder(6)]
         public MoveInfo MoveInfo { get; set; }
+
+        public static UnitInfo Create(long unitId = default, int configId = default, int type = default, Unity.Mathematics.float3 position = default, Unity.Mathematics.float3 forward = default, MoveInfo moveInfo = default, bool isFromPool = false)
+        {
+            UnitInfo msg = ObjectPool.Instance.Fetch(typeof(UnitInfo), isFromPool) as UnitInfo;
+            msg.Set(unitId, configId, type, position, forward, moveInfo);
+            return msg;
+        }
+
+        public void Set(long unitId = default, int configId = default, int type = default, Unity.Mathematics.float3 position = default, Unity.Mathematics.float3 forward = default, MoveInfo moveInfo = default)
+        {
+            this.UnitId = unitId;
+            this.ConfigId = configId;
+            this.Type = type;
+            this.Position = position;
+            this.Forward = forward;
+            this.MoveInfo = moveInfo;
+        }
 
         public override void Dispose()
         {
@@ -280,13 +347,13 @@ namespace ET
     [Message(OuterMessage.M2C_CreateUnits)]
     public partial class M2C_CreateUnits : MessageObject, IMessage
     {
+        [MemoryPackOrder(0)]
+        public List<UnitInfo> Units { get; set; } = new();
+
         public static M2C_CreateUnits Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(M2C_CreateUnits), isFromPool) as M2C_CreateUnits;
         }
-
-        [MemoryPackOrder(0)]
-        public List<UnitInfo> Units { get; set; } = new();
 
         public override void Dispose()
         {
@@ -305,13 +372,20 @@ namespace ET
     [Message(OuterMessage.M2C_CreateMyUnit)]
     public partial class M2C_CreateMyUnit : MessageObject, IMessage
     {
-        public static M2C_CreateMyUnit Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_CreateMyUnit), isFromPool) as M2C_CreateMyUnit;
-        }
-
         [MemoryPackOrder(0)]
         public UnitInfo Unit { get; set; }
+
+        public static M2C_CreateMyUnit Create(UnitInfo unit = default, bool isFromPool = false)
+        {
+            M2C_CreateMyUnit msg = ObjectPool.Instance.Fetch(typeof(M2C_CreateMyUnit), isFromPool) as M2C_CreateMyUnit;
+            msg.Set(unit);
+            return msg;
+        }
+
+        public void Set(UnitInfo unit = default)
+        {
+            this.Unit = unit;
+        }
 
         public override void Dispose()
         {
@@ -330,16 +404,24 @@ namespace ET
     [Message(OuterMessage.M2C_StartSceneChange)]
     public partial class M2C_StartSceneChange : MessageObject, IMessage
     {
-        public static M2C_StartSceneChange Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_StartSceneChange), isFromPool) as M2C_StartSceneChange;
-        }
-
         [MemoryPackOrder(0)]
         public long SceneInstanceId { get; set; }
 
         [MemoryPackOrder(1)]
         public string SceneName { get; set; }
+
+        public static M2C_StartSceneChange Create(long sceneInstanceId = default, string sceneName = default, bool isFromPool = false)
+        {
+            M2C_StartSceneChange msg = ObjectPool.Instance.Fetch(typeof(M2C_StartSceneChange), isFromPool) as M2C_StartSceneChange;
+            msg.Set(sceneInstanceId, sceneName);
+            return msg;
+        }
+
+        public void Set(long sceneInstanceId = default, string sceneName = default)
+        {
+            this.SceneInstanceId = sceneInstanceId;
+            this.SceneName = sceneName;
+        }
 
         public override void Dispose()
         {
@@ -359,13 +441,13 @@ namespace ET
     [Message(OuterMessage.M2C_RemoveUnits)]
     public partial class M2C_RemoveUnits : MessageObject, IMessage
     {
+        [MemoryPackOrder(0)]
+        public List<long> Units { get; set; } = new();
+
         public static M2C_RemoveUnits Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(M2C_RemoveUnits), isFromPool) as M2C_RemoveUnits;
         }
-
-        [MemoryPackOrder(0)]
-        public List<long> Units { get; set; } = new();
 
         public override void Dispose()
         {
@@ -384,16 +466,23 @@ namespace ET
     [Message(OuterMessage.C2M_PathfindingResult)]
     public partial class C2M_PathfindingResult : MessageObject, ILocationMessage
     {
-        public static C2M_PathfindingResult Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_PathfindingResult), isFromPool) as C2M_PathfindingResult;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public Unity.Mathematics.float3 Position { get; set; }
+
+        public static C2M_PathfindingResult Create(Unity.Mathematics.float3 position = default, bool isFromPool = false)
+        {
+            C2M_PathfindingResult msg = ObjectPool.Instance.Fetch(typeof(C2M_PathfindingResult), isFromPool) as C2M_PathfindingResult;
+            msg.Set(position);
+            return msg;
+        }
+
+        public void Set(Unity.Mathematics.float3 position = default)
+        {
+            this.Position = position;
+        }
 
         public override void Dispose()
         {
@@ -413,13 +502,13 @@ namespace ET
     [Message(OuterMessage.C2M_Stop)]
     public partial class C2M_Stop : MessageObject, ILocationMessage
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2M_Stop Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2M_Stop), isFromPool) as C2M_Stop;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -438,11 +527,6 @@ namespace ET
     [Message(OuterMessage.M2C_PathfindingResult)]
     public partial class M2C_PathfindingResult : MessageObject, IMessage
     {
-        public static M2C_PathfindingResult Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_PathfindingResult), isFromPool) as M2C_PathfindingResult;
-        }
-
         [MemoryPackOrder(0)]
         public long Id { get; set; }
 
@@ -451,6 +535,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public List<Unity.Mathematics.float3> Points { get; set; } = new();
+
+        public static M2C_PathfindingResult Create(long id = default, Unity.Mathematics.float3 position = default, bool isFromPool = false)
+        {
+            M2C_PathfindingResult msg = ObjectPool.Instance.Fetch(typeof(M2C_PathfindingResult), isFromPool) as M2C_PathfindingResult;
+            msg.Set(id, position);
+            return msg;
+        }
+
+        public void Set(long id = default, Unity.Mathematics.float3 position = default)
+        {
+            this.Id = id;
+            this.Position = position;
+        }
 
         public override void Dispose()
         {
@@ -471,11 +568,6 @@ namespace ET
     [Message(OuterMessage.M2C_Stop)]
     public partial class M2C_Stop : MessageObject, IMessage
     {
-        public static M2C_Stop Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_Stop), isFromPool) as M2C_Stop;
-        }
-
         [MemoryPackOrder(0)]
         public int Error { get; set; }
 
@@ -487,6 +579,21 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public Unity.Mathematics.quaternion Rotation { get; set; }
+
+        public static M2C_Stop Create(int error = default, long id = default, Unity.Mathematics.float3 position = default, Unity.Mathematics.quaternion rotation = default, bool isFromPool = false)
+        {
+            M2C_Stop msg = ObjectPool.Instance.Fetch(typeof(M2C_Stop), isFromPool) as M2C_Stop;
+            msg.Set(error, id, position, rotation);
+            return msg;
+        }
+
+        public void Set(int error = default, long id = default, Unity.Mathematics.float3 position = default, Unity.Mathematics.quaternion rotation = default)
+        {
+            this.Error = error;
+            this.Id = id;
+            this.Position = position;
+            this.Rotation = rotation;
+        }
 
         public override void Dispose()
         {
@@ -509,13 +616,13 @@ namespace ET
     [ResponseType(nameof(G2C_Ping))]
     public partial class C2G_Ping : MessageObject, ISessionRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2G_Ping Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2G_Ping), isFromPool) as C2G_Ping;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -534,11 +641,6 @@ namespace ET
     [Message(OuterMessage.G2C_Ping)]
     public partial class G2C_Ping : MessageObject, ISessionResponse
     {
-        public static G2C_Ping Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_Ping), isFromPool) as G2C_Ping;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -550,6 +652,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public long Time { get; set; }
+
+        public static G2C_Ping Create(int error = default, string message = default, long time = default, bool isFromPool = false)
+        {
+            G2C_Ping msg = ObjectPool.Instance.Fetch(typeof(G2C_Ping), isFromPool) as G2C_Ping;
+            msg.Set(error, message, time);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, long time = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.Time = time;
+        }
 
         public override void Dispose()
         {
@@ -583,7 +699,6 @@ namespace ET
                 return;
             }
 
-            
             ObjectPool.Instance.Recycle(this);
         }
     }
@@ -593,11 +708,6 @@ namespace ET
     [ResponseType(nameof(M2C_Reload))]
     public partial class C2M_Reload : MessageObject, ISessionRequest
     {
-        public static C2M_Reload Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_Reload), isFromPool) as C2M_Reload;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -606,6 +716,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Password { get; set; }
+
+        public static C2M_Reload Create(string account = default, string password = default, bool isFromPool = false)
+        {
+            C2M_Reload msg = ObjectPool.Instance.Fetch(typeof(C2M_Reload), isFromPool) as C2M_Reload;
+            msg.Set(account, password);
+            return msg;
+        }
+
+        public void Set(string account = default, string password = default)
+        {
+            this.Account = account;
+            this.Password = password;
+        }
 
         public override void Dispose()
         {
@@ -626,11 +749,6 @@ namespace ET
     [Message(OuterMessage.M2C_Reload)]
     public partial class M2C_Reload : MessageObject, ISessionResponse
     {
-        public static M2C_Reload Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_Reload), isFromPool) as M2C_Reload;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -639,6 +757,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static M2C_Reload Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            M2C_Reload msg = ObjectPool.Instance.Fetch(typeof(M2C_Reload), isFromPool) as M2C_Reload;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -660,11 +791,6 @@ namespace ET
     [ResponseType(nameof(R2C_Login))]
     public partial class C2R_Login : MessageObject, ISessionRequest
     {
-        public static C2R_Login Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2R_Login), isFromPool) as C2R_Login;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -679,6 +805,30 @@ namespace ET
         /// </summary>
         [MemoryPackOrder(2)]
         public string Password { get; set; }
+
+        /// <summary>
+        /// Create C2R_Login
+        /// </summary>
+        /// <param name="account">帐号</param>
+        /// <param name="password">密码</param>
+        /// <param name="isFromPool"></param>
+        public static C2R_Login Create(string account = default, string password = default, bool isFromPool = false)
+        {
+            C2R_Login msg = ObjectPool.Instance.Fetch(typeof(C2R_Login), isFromPool) as C2R_Login;
+            msg.Set(account, password);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set C2R_Login
+        /// </summary>
+        /// <param name="account">帐号</param>
+        /// <param name="password">密码</param>
+        public void Set(string account = default, string password = default)
+        {
+            this.Account = account;
+            this.Password = password;
+        }
 
         public override void Dispose()
         {
@@ -699,11 +849,6 @@ namespace ET
     [Message(OuterMessage.R2C_Login)]
     public partial class R2C_Login : MessageObject, ISessionResponse
     {
-        public static R2C_Login Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(R2C_Login), isFromPool) as R2C_Login;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -721,6 +866,22 @@ namespace ET
 
         [MemoryPackOrder(5)]
         public long GateId { get; set; }
+
+        public static R2C_Login Create(int error = default, string message = default, string address = default, long key = default, long gateId = default, bool isFromPool = false)
+        {
+            R2C_Login msg = ObjectPool.Instance.Fetch(typeof(R2C_Login), isFromPool) as R2C_Login;
+            msg.Set(error, message, address, key, gateId);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, string address = default, long key = default, long gateId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.Address = address;
+            this.Key = key;
+            this.GateId = gateId;
+        }
 
         public override void Dispose()
         {
@@ -745,11 +906,6 @@ namespace ET
     [ResponseType(nameof(G2C_LoginGate))]
     public partial class C2G_LoginGate : MessageObject, ISessionRequest
     {
-        public static C2G_LoginGate Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2G_LoginGate), isFromPool) as C2G_LoginGate;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -761,6 +917,30 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public long GateId { get; set; }
+
+        /// <summary>
+        /// Create C2G_LoginGate
+        /// </summary>
+        /// <param name="key">帐号</param>
+        /// <param name="gateId">GateId</param>
+        /// <param name="isFromPool"></param>
+        public static C2G_LoginGate Create(long key = default, long gateId = default, bool isFromPool = false)
+        {
+            C2G_LoginGate msg = ObjectPool.Instance.Fetch(typeof(C2G_LoginGate), isFromPool) as C2G_LoginGate;
+            msg.Set(key, gateId);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set C2G_LoginGate
+        /// </summary>
+        /// <param name="key">帐号</param>
+        /// <param name="gateId">GateId</param>
+        public void Set(long key = default, long gateId = default)
+        {
+            this.Key = key;
+            this.GateId = gateId;
+        }
 
         public override void Dispose()
         {
@@ -781,11 +961,6 @@ namespace ET
     [Message(OuterMessage.G2C_LoginGate)]
     public partial class G2C_LoginGate : MessageObject, ISessionResponse
     {
-        public static G2C_LoginGate Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_LoginGate), isFromPool) as G2C_LoginGate;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -797,6 +972,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public long PlayerId { get; set; }
+
+        public static G2C_LoginGate Create(int error = default, string message = default, long playerId = default, bool isFromPool = false)
+        {
+            G2C_LoginGate msg = ObjectPool.Instance.Fetch(typeof(G2C_LoginGate), isFromPool) as G2C_LoginGate;
+            msg.Set(error, message, playerId);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, long playerId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.PlayerId = playerId;
+        }
 
         public override void Dispose()
         {
@@ -818,13 +1007,20 @@ namespace ET
     [Message(OuterMessage.G2C_TestHotfixMessage)]
     public partial class G2C_TestHotfixMessage : MessageObject, ISessionMessage
     {
-        public static G2C_TestHotfixMessage Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_TestHotfixMessage), isFromPool) as G2C_TestHotfixMessage;
-        }
-
         [MemoryPackOrder(0)]
         public string Info { get; set; }
+
+        public static G2C_TestHotfixMessage Create(string info = default, bool isFromPool = false)
+        {
+            G2C_TestHotfixMessage msg = ObjectPool.Instance.Fetch(typeof(G2C_TestHotfixMessage), isFromPool) as G2C_TestHotfixMessage;
+            msg.Set(info);
+            return msg;
+        }
+
+        public void Set(string info = default)
+        {
+            this.Info = info;
+        }
 
         public override void Dispose()
         {
@@ -844,16 +1040,23 @@ namespace ET
     [ResponseType(nameof(M2C_TestRobotCase))]
     public partial class C2M_TestRobotCase : MessageObject, ILocationRequest
     {
-        public static C2M_TestRobotCase Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_TestRobotCase), isFromPool) as C2M_TestRobotCase;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public int N { get; set; }
+
+        public static C2M_TestRobotCase Create(int n = default, bool isFromPool = false)
+        {
+            C2M_TestRobotCase msg = ObjectPool.Instance.Fetch(typeof(C2M_TestRobotCase), isFromPool) as C2M_TestRobotCase;
+            msg.Set(n);
+            return msg;
+        }
+
+        public void Set(int n = default)
+        {
+            this.N = n;
+        }
 
         public override void Dispose()
         {
@@ -873,11 +1076,6 @@ namespace ET
     [Message(OuterMessage.M2C_TestRobotCase)]
     public partial class M2C_TestRobotCase : MessageObject, ILocationResponse
     {
-        public static M2C_TestRobotCase Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_TestRobotCase), isFromPool) as M2C_TestRobotCase;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -889,6 +1087,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public int N { get; set; }
+
+        public static M2C_TestRobotCase Create(int error = default, string message = default, int n = default, bool isFromPool = false)
+        {
+            M2C_TestRobotCase msg = ObjectPool.Instance.Fetch(typeof(M2C_TestRobotCase), isFromPool) as M2C_TestRobotCase;
+            msg.Set(error, message, n);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, int n = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.N = n;
+        }
 
         public override void Dispose()
         {
@@ -910,16 +1122,23 @@ namespace ET
     [Message(OuterMessage.C2M_TestRobotCase2)]
     public partial class C2M_TestRobotCase2 : MessageObject, ILocationMessage
     {
-        public static C2M_TestRobotCase2 Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_TestRobotCase2), isFromPool) as C2M_TestRobotCase2;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public int N { get; set; }
+
+        public static C2M_TestRobotCase2 Create(int n = default, bool isFromPool = false)
+        {
+            C2M_TestRobotCase2 msg = ObjectPool.Instance.Fetch(typeof(C2M_TestRobotCase2), isFromPool) as C2M_TestRobotCase2;
+            msg.Set(n);
+            return msg;
+        }
+
+        public void Set(int n = default)
+        {
+            this.N = n;
+        }
 
         public override void Dispose()
         {
@@ -939,16 +1158,23 @@ namespace ET
     [Message(OuterMessage.M2C_TestRobotCase2)]
     public partial class M2C_TestRobotCase2 : MessageObject, ILocationMessage
     {
-        public static M2C_TestRobotCase2 Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_TestRobotCase2), isFromPool) as M2C_TestRobotCase2;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public int N { get; set; }
+
+        public static M2C_TestRobotCase2 Create(int n = default, bool isFromPool = false)
+        {
+            M2C_TestRobotCase2 msg = ObjectPool.Instance.Fetch(typeof(M2C_TestRobotCase2), isFromPool) as M2C_TestRobotCase2;
+            msg.Set(n);
+            return msg;
+        }
+
+        public void Set(int n = default)
+        {
+            this.N = n;
+        }
 
         public override void Dispose()
         {
@@ -969,13 +1195,13 @@ namespace ET
     [ResponseType(nameof(M2C_TransferMap))]
     public partial class C2M_TransferMap : MessageObject, ILocationRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2M_TransferMap Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2M_TransferMap), isFromPool) as C2M_TransferMap;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -994,11 +1220,6 @@ namespace ET
     [Message(OuterMessage.M2C_TransferMap)]
     public partial class M2C_TransferMap : MessageObject, ILocationResponse
     {
-        public static M2C_TransferMap Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_TransferMap), isFromPool) as M2C_TransferMap;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -1007,6 +1228,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static M2C_TransferMap Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            M2C_TransferMap msg = ObjectPool.Instance.Fetch(typeof(M2C_TransferMap), isFromPool) as M2C_TransferMap;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -1028,13 +1262,13 @@ namespace ET
     [ResponseType(nameof(G2C_Benchmark))]
     public partial class C2G_Benchmark : MessageObject, ISessionRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2G_Benchmark Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2G_Benchmark), isFromPool) as C2G_Benchmark;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -1053,11 +1287,6 @@ namespace ET
     [Message(OuterMessage.G2C_Benchmark)]
     public partial class G2C_Benchmark : MessageObject, ISessionResponse
     {
-        public static G2C_Benchmark Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_Benchmark), isFromPool) as G2C_Benchmark;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -1066,6 +1295,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static G2C_Benchmark Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            G2C_Benchmark msg = ObjectPool.Instance.Fetch(typeof(G2C_Benchmark), isFromPool) as G2C_Benchmark;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {

--- a/Unity/Assets/Scripts/Model/Generate/ClientServer/Message/ClientMessage_C_1000.cs
+++ b/Unity/Assets/Scripts/Model/Generate/ClientServer/Message/ClientMessage_C_1000.cs
@@ -8,11 +8,6 @@ namespace ET
     [ResponseType(nameof(NetClient2Main_Login))]
     public partial class Main2NetClient_Login : MessageObject, IRequest
     {
-        public static Main2NetClient_Login Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Main2NetClient_Login), isFromPool) as Main2NetClient_Login;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -30,6 +25,33 @@ namespace ET
         /// </summary>
         [MemoryPackOrder(3)]
         public string Password { get; set; }
+
+        /// <summary>
+        /// Create Main2NetClient_Login
+        /// </summary>
+        /// <param name="ownerFiberId">OwnerFiberId</param>
+        /// <param name="account">账号</param>
+        /// <param name="password">密码</param>
+        /// <param name="isFromPool"></param>
+        public static Main2NetClient_Login Create(int ownerFiberId = default, string account = default, string password = default, bool isFromPool = false)
+        {
+            Main2NetClient_Login msg = ObjectPool.Instance.Fetch(typeof(Main2NetClient_Login), isFromPool) as Main2NetClient_Login;
+            msg.Set(ownerFiberId, account, password);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set Main2NetClient_Login
+        /// </summary>
+        /// <param name="ownerFiberId">OwnerFiberId</param>
+        /// <param name="account">账号</param>
+        /// <param name="password">密码</param>
+        public void Set(int ownerFiberId = default, string account = default, string password = default)
+        {
+            this.OwnerFiberId = ownerFiberId;
+            this.Account = account;
+            this.Password = password;
+        }
 
         public override void Dispose()
         {
@@ -51,11 +73,6 @@ namespace ET
     [Message(ClientMessage.NetClient2Main_Login)]
     public partial class NetClient2Main_Login : MessageObject, IResponse
     {
-        public static NetClient2Main_Login Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(NetClient2Main_Login), isFromPool) as NetClient2Main_Login;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -67,6 +84,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public long PlayerId { get; set; }
+
+        public static NetClient2Main_Login Create(int error = default, string message = default, long playerId = default, bool isFromPool = false)
+        {
+            NetClient2Main_Login msg = ObjectPool.Instance.Fetch(typeof(NetClient2Main_Login), isFromPool) as NetClient2Main_Login;
+            msg.Set(error, message, playerId);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, long playerId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.PlayerId = playerId;
+        }
 
         public override void Dispose()
         {

--- a/Unity/Assets/Scripts/Model/Generate/ClientServer/Message/InnerMessage_S_20001.cs
+++ b/Unity/Assets/Scripts/Model/Generate/ClientServer/Message/InnerMessage_S_20001.cs
@@ -8,11 +8,6 @@ namespace ET
     [ResponseType(nameof(ObjectQueryResponse))]
     public partial class ObjectQueryRequest : MessageObject, IRequest
     {
-        public static ObjectQueryRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectQueryRequest), isFromPool) as ObjectQueryRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -21,6 +16,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public long InstanceId { get; set; }
+
+        public static ObjectQueryRequest Create(long key = default, long instanceId = default, bool isFromPool = false)
+        {
+            ObjectQueryRequest msg = ObjectPool.Instance.Fetch(typeof(ObjectQueryRequest), isFromPool) as ObjectQueryRequest;
+            msg.Set(key, instanceId);
+            return msg;
+        }
+
+        public void Set(long key = default, long instanceId = default)
+        {
+            this.Key = key;
+            this.InstanceId = instanceId;
+        }
 
         public override void Dispose()
         {
@@ -42,13 +50,13 @@ namespace ET
     [ResponseType(nameof(A2M_Reload))]
     public partial class M2A_Reload : MessageObject, IRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static M2A_Reload Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(M2A_Reload), isFromPool) as M2A_Reload;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -67,11 +75,6 @@ namespace ET
     [Message(InnerMessage.A2M_Reload)]
     public partial class A2M_Reload : MessageObject, IResponse
     {
-        public static A2M_Reload Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(A2M_Reload), isFromPool) as A2M_Reload;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -80,6 +83,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static A2M_Reload Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            A2M_Reload msg = ObjectPool.Instance.Fetch(typeof(A2M_Reload), isFromPool) as A2M_Reload;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -101,11 +117,6 @@ namespace ET
     [ResponseType(nameof(G2G_LockResponse))]
     public partial class G2G_LockRequest : MessageObject, IRequest
     {
-        public static G2G_LockRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2G_LockRequest), isFromPool) as G2G_LockRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -114,6 +125,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Address { get; set; }
+
+        public static G2G_LockRequest Create(long id = default, string address = default, bool isFromPool = false)
+        {
+            G2G_LockRequest msg = ObjectPool.Instance.Fetch(typeof(G2G_LockRequest), isFromPool) as G2G_LockRequest;
+            msg.Set(id, address);
+            return msg;
+        }
+
+        public void Set(long id = default, string address = default)
+        {
+            this.Id = id;
+            this.Address = address;
+        }
 
         public override void Dispose()
         {
@@ -134,11 +158,6 @@ namespace ET
     [Message(InnerMessage.G2G_LockResponse)]
     public partial class G2G_LockResponse : MessageObject, IResponse
     {
-        public static G2G_LockResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2G_LockResponse), isFromPool) as G2G_LockResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -147,6 +166,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static G2G_LockResponse Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            G2G_LockResponse msg = ObjectPool.Instance.Fetch(typeof(G2G_LockResponse), isFromPool) as G2G_LockResponse;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -168,11 +200,6 @@ namespace ET
     [ResponseType(nameof(G2G_LockReleaseResponse))]
     public partial class G2G_LockReleaseRequest : MessageObject, IRequest
     {
-        public static G2G_LockReleaseRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2G_LockReleaseRequest), isFromPool) as G2G_LockReleaseRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -181,6 +208,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Address { get; set; }
+
+        public static G2G_LockReleaseRequest Create(long id = default, string address = default, bool isFromPool = false)
+        {
+            G2G_LockReleaseRequest msg = ObjectPool.Instance.Fetch(typeof(G2G_LockReleaseRequest), isFromPool) as G2G_LockReleaseRequest;
+            msg.Set(id, address);
+            return msg;
+        }
+
+        public void Set(long id = default, string address = default)
+        {
+            this.Id = id;
+            this.Address = address;
+        }
 
         public override void Dispose()
         {
@@ -201,11 +241,6 @@ namespace ET
     [Message(InnerMessage.G2G_LockReleaseResponse)]
     public partial class G2G_LockReleaseResponse : MessageObject, IResponse
     {
-        public static G2G_LockReleaseResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2G_LockReleaseResponse), isFromPool) as G2G_LockReleaseResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -214,6 +249,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static G2G_LockReleaseResponse Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            G2G_LockReleaseResponse msg = ObjectPool.Instance.Fetch(typeof(G2G_LockReleaseResponse), isFromPool) as G2G_LockReleaseResponse;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -235,11 +283,6 @@ namespace ET
     [ResponseType(nameof(ObjectAddResponse))]
     public partial class ObjectAddRequest : MessageObject, IRequest
     {
-        public static ObjectAddRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectAddRequest), isFromPool) as ObjectAddRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -251,6 +294,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public ActorId ActorId { get; set; }
+
+        public static ObjectAddRequest Create(int type = default, long key = default, ActorId actorId = default, bool isFromPool = false)
+        {
+            ObjectAddRequest msg = ObjectPool.Instance.Fetch(typeof(ObjectAddRequest), isFromPool) as ObjectAddRequest;
+            msg.Set(type, key, actorId);
+            return msg;
+        }
+
+        public void Set(int type = default, long key = default, ActorId actorId = default)
+        {
+            this.Type = type;
+            this.Key = key;
+            this.ActorId = actorId;
+        }
 
         public override void Dispose()
         {
@@ -272,11 +329,6 @@ namespace ET
     [Message(InnerMessage.ObjectAddResponse)]
     public partial class ObjectAddResponse : MessageObject, IResponse
     {
-        public static ObjectAddResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectAddResponse), isFromPool) as ObjectAddResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -285,6 +337,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static ObjectAddResponse Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            ObjectAddResponse msg = ObjectPool.Instance.Fetch(typeof(ObjectAddResponse), isFromPool) as ObjectAddResponse;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -306,11 +371,6 @@ namespace ET
     [ResponseType(nameof(ObjectLockResponse))]
     public partial class ObjectLockRequest : MessageObject, IRequest
     {
-        public static ObjectLockRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectLockRequest), isFromPool) as ObjectLockRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -325,6 +385,21 @@ namespace ET
 
         [MemoryPackOrder(4)]
         public int Time { get; set; }
+
+        public static ObjectLockRequest Create(int type = default, long key = default, ActorId actorId = default, int time = default, bool isFromPool = false)
+        {
+            ObjectLockRequest msg = ObjectPool.Instance.Fetch(typeof(ObjectLockRequest), isFromPool) as ObjectLockRequest;
+            msg.Set(type, key, actorId, time);
+            return msg;
+        }
+
+        public void Set(int type = default, long key = default, ActorId actorId = default, int time = default)
+        {
+            this.Type = type;
+            this.Key = key;
+            this.ActorId = actorId;
+            this.Time = time;
+        }
 
         public override void Dispose()
         {
@@ -347,11 +422,6 @@ namespace ET
     [Message(InnerMessage.ObjectLockResponse)]
     public partial class ObjectLockResponse : MessageObject, IResponse
     {
-        public static ObjectLockResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectLockResponse), isFromPool) as ObjectLockResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -360,6 +430,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static ObjectLockResponse Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            ObjectLockResponse msg = ObjectPool.Instance.Fetch(typeof(ObjectLockResponse), isFromPool) as ObjectLockResponse;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -381,11 +464,6 @@ namespace ET
     [ResponseType(nameof(ObjectUnLockResponse))]
     public partial class ObjectUnLockRequest : MessageObject, IRequest
     {
-        public static ObjectUnLockRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectUnLockRequest), isFromPool) as ObjectUnLockRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -400,6 +478,21 @@ namespace ET
 
         [MemoryPackOrder(4)]
         public ActorId NewActorId { get; set; }
+
+        public static ObjectUnLockRequest Create(int type = default, long key = default, ActorId oldActorId = default, ActorId newActorId = default, bool isFromPool = false)
+        {
+            ObjectUnLockRequest msg = ObjectPool.Instance.Fetch(typeof(ObjectUnLockRequest), isFromPool) as ObjectUnLockRequest;
+            msg.Set(type, key, oldActorId, newActorId);
+            return msg;
+        }
+
+        public void Set(int type = default, long key = default, ActorId oldActorId = default, ActorId newActorId = default)
+        {
+            this.Type = type;
+            this.Key = key;
+            this.OldActorId = oldActorId;
+            this.NewActorId = newActorId;
+        }
 
         public override void Dispose()
         {
@@ -422,11 +515,6 @@ namespace ET
     [Message(InnerMessage.ObjectUnLockResponse)]
     public partial class ObjectUnLockResponse : MessageObject, IResponse
     {
-        public static ObjectUnLockResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectUnLockResponse), isFromPool) as ObjectUnLockResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -435,6 +523,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static ObjectUnLockResponse Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            ObjectUnLockResponse msg = ObjectPool.Instance.Fetch(typeof(ObjectUnLockResponse), isFromPool) as ObjectUnLockResponse;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -456,11 +557,6 @@ namespace ET
     [ResponseType(nameof(ObjectRemoveResponse))]
     public partial class ObjectRemoveRequest : MessageObject, IRequest
     {
-        public static ObjectRemoveRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectRemoveRequest), isFromPool) as ObjectRemoveRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -469,6 +565,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public long Key { get; set; }
+
+        public static ObjectRemoveRequest Create(int type = default, long key = default, bool isFromPool = false)
+        {
+            ObjectRemoveRequest msg = ObjectPool.Instance.Fetch(typeof(ObjectRemoveRequest), isFromPool) as ObjectRemoveRequest;
+            msg.Set(type, key);
+            return msg;
+        }
+
+        public void Set(int type = default, long key = default)
+        {
+            this.Type = type;
+            this.Key = key;
+        }
 
         public override void Dispose()
         {
@@ -489,11 +598,6 @@ namespace ET
     [Message(InnerMessage.ObjectRemoveResponse)]
     public partial class ObjectRemoveResponse : MessageObject, IResponse
     {
-        public static ObjectRemoveResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectRemoveResponse), isFromPool) as ObjectRemoveResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -502,6 +606,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static ObjectRemoveResponse Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            ObjectRemoveResponse msg = ObjectPool.Instance.Fetch(typeof(ObjectRemoveResponse), isFromPool) as ObjectRemoveResponse;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -523,11 +640,6 @@ namespace ET
     [ResponseType(nameof(ObjectGetResponse))]
     public partial class ObjectGetRequest : MessageObject, IRequest
     {
-        public static ObjectGetRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectGetRequest), isFromPool) as ObjectGetRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -536,6 +648,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public long Key { get; set; }
+
+        public static ObjectGetRequest Create(int type = default, long key = default, bool isFromPool = false)
+        {
+            ObjectGetRequest msg = ObjectPool.Instance.Fetch(typeof(ObjectGetRequest), isFromPool) as ObjectGetRequest;
+            msg.Set(type, key);
+            return msg;
+        }
+
+        public void Set(int type = default, long key = default)
+        {
+            this.Type = type;
+            this.Key = key;
+        }
 
         public override void Dispose()
         {
@@ -556,11 +681,6 @@ namespace ET
     [Message(InnerMessage.ObjectGetResponse)]
     public partial class ObjectGetResponse : MessageObject, IResponse
     {
-        public static ObjectGetResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectGetResponse), isFromPool) as ObjectGetResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -575,6 +695,21 @@ namespace ET
 
         [MemoryPackOrder(4)]
         public ActorId ActorId { get; set; }
+
+        public static ObjectGetResponse Create(int error = default, string message = default, int type = default, ActorId actorId = default, bool isFromPool = false)
+        {
+            ObjectGetResponse msg = ObjectPool.Instance.Fetch(typeof(ObjectGetResponse), isFromPool) as ObjectGetResponse;
+            msg.Set(error, message, type, actorId);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, int type = default, ActorId actorId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.Type = type;
+            this.ActorId = actorId;
+        }
 
         public override void Dispose()
         {
@@ -598,16 +733,23 @@ namespace ET
     [ResponseType(nameof(G2R_GetLoginKey))]
     public partial class R2G_GetLoginKey : MessageObject, IRequest
     {
-        public static R2G_GetLoginKey Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(R2G_GetLoginKey), isFromPool) as R2G_GetLoginKey;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public string Account { get; set; }
+
+        public static R2G_GetLoginKey Create(string account = default, bool isFromPool = false)
+        {
+            R2G_GetLoginKey msg = ObjectPool.Instance.Fetch(typeof(R2G_GetLoginKey), isFromPool) as R2G_GetLoginKey;
+            msg.Set(account);
+            return msg;
+        }
+
+        public void Set(string account = default)
+        {
+            this.Account = account;
+        }
 
         public override void Dispose()
         {
@@ -627,11 +769,6 @@ namespace ET
     [Message(InnerMessage.G2R_GetLoginKey)]
     public partial class G2R_GetLoginKey : MessageObject, IResponse
     {
-        public static G2R_GetLoginKey Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2R_GetLoginKey), isFromPool) as G2R_GetLoginKey;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -646,6 +783,21 @@ namespace ET
 
         [MemoryPackOrder(4)]
         public long GateId { get; set; }
+
+        public static G2R_GetLoginKey Create(int error = default, string message = default, long key = default, long gateId = default, bool isFromPool = false)
+        {
+            G2R_GetLoginKey msg = ObjectPool.Instance.Fetch(typeof(G2R_GetLoginKey), isFromPool) as G2R_GetLoginKey;
+            msg.Set(error, message, key, gateId);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, long key = default, long gateId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.Key = key;
+            this.GateId = gateId;
+        }
 
         public override void Dispose()
         {
@@ -668,13 +820,13 @@ namespace ET
     [Message(InnerMessage.G2M_SessionDisconnect)]
     public partial class G2M_SessionDisconnect : MessageObject, ILocationMessage
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static G2M_SessionDisconnect Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(G2M_SessionDisconnect), isFromPool) as G2M_SessionDisconnect;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -693,11 +845,6 @@ namespace ET
     [Message(InnerMessage.ObjectQueryResponse)]
     public partial class ObjectQueryResponse : MessageObject, IResponse
     {
-        public static ObjectQueryResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectQueryResponse), isFromPool) as ObjectQueryResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -709,6 +856,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public byte[] Entity { get; set; }
+
+        public static ObjectQueryResponse Create(int error = default, string message = default, byte[] entity = default, bool isFromPool = false)
+        {
+            ObjectQueryResponse msg = ObjectPool.Instance.Fetch(typeof(ObjectQueryResponse), isFromPool) as ObjectQueryResponse;
+            msg.Set(error, message, entity);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, byte[] entity = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.Entity = entity;
+        }
 
         public override void Dispose()
         {
@@ -731,11 +892,6 @@ namespace ET
     [ResponseType(nameof(M2M_UnitTransferResponse))]
     public partial class M2M_UnitTransferRequest : MessageObject, IRequest
     {
-        public static M2M_UnitTransferRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2M_UnitTransferRequest), isFromPool) as M2M_UnitTransferRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -747,6 +903,19 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public List<byte[]> Entitys { get; set; } = new();
+
+        public static M2M_UnitTransferRequest Create(ActorId oldActorId = default, byte[] unit = default, bool isFromPool = false)
+        {
+            M2M_UnitTransferRequest msg = ObjectPool.Instance.Fetch(typeof(M2M_UnitTransferRequest), isFromPool) as M2M_UnitTransferRequest;
+            msg.Set(oldActorId, unit);
+            return msg;
+        }
+
+        public void Set(ActorId oldActorId = default, byte[] unit = default)
+        {
+            this.OldActorId = oldActorId;
+            this.Unit = unit;
+        }
 
         public override void Dispose()
         {
@@ -768,11 +937,6 @@ namespace ET
     [Message(InnerMessage.M2M_UnitTransferResponse)]
     public partial class M2M_UnitTransferResponse : MessageObject, IResponse
     {
-        public static M2M_UnitTransferResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2M_UnitTransferResponse), isFromPool) as M2M_UnitTransferResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -781,6 +945,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static M2M_UnitTransferResponse Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            M2M_UnitTransferResponse msg = ObjectPool.Instance.Fetch(typeof(M2M_UnitTransferResponse), isFromPool) as M2M_UnitTransferResponse;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {

--- a/Unity/Assets/Scripts/Model/Generate/ClientServer/Message/LockStepInner_S_21001.cs
+++ b/Unity/Assets/Scripts/Model/Generate/ClientServer/Message/LockStepInner_S_21001.cs
@@ -11,16 +11,23 @@ namespace ET
     [ResponseType(nameof(Match2G_Match))]
     public partial class G2Match_Match : MessageObject, IRequest
     {
-        public static G2Match_Match Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2Match_Match), isFromPool) as G2Match_Match;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public long Id { get; set; }
+
+        public static G2Match_Match Create(long id = default, bool isFromPool = false)
+        {
+            G2Match_Match msg = ObjectPool.Instance.Fetch(typeof(G2Match_Match), isFromPool) as G2Match_Match;
+            msg.Set(id);
+            return msg;
+        }
+
+        public void Set(long id = default)
+        {
+            this.Id = id;
+        }
 
         public override void Dispose()
         {
@@ -40,11 +47,6 @@ namespace ET
     [Message(LockStepInner.Match2G_Match)]
     public partial class Match2G_Match : MessageObject, IResponse
     {
-        public static Match2G_Match Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Match2G_Match), isFromPool) as Match2G_Match;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -53,6 +55,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static Match2G_Match Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            Match2G_Match msg = ObjectPool.Instance.Fetch(typeof(Match2G_Match), isFromPool) as Match2G_Match;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -74,16 +89,16 @@ namespace ET
     [ResponseType(nameof(Map2Match_GetRoom))]
     public partial class Match2Map_GetRoom : MessageObject, IRequest
     {
-        public static Match2Map_GetRoom Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Match2Map_GetRoom), isFromPool) as Match2Map_GetRoom;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public List<long> PlayerIds { get; set; } = new();
+
+        public static Match2Map_GetRoom Create(bool isFromPool = false)
+        {
+            return ObjectPool.Instance.Fetch(typeof(Match2Map_GetRoom), isFromPool) as Match2Map_GetRoom;
+        }
 
         public override void Dispose()
         {
@@ -103,11 +118,6 @@ namespace ET
     [Message(LockStepInner.Map2Match_GetRoom)]
     public partial class Map2Match_GetRoom : MessageObject, IResponse
     {
-        public static Map2Match_GetRoom Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Map2Match_GetRoom), isFromPool) as Map2Match_GetRoom;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -122,6 +132,33 @@ namespace ET
         /// </summary>
         [MemoryPackOrder(3)]
         public ActorId ActorId { get; set; }
+
+        /// <summary>
+        /// Create Map2Match_GetRoom
+        /// </summary>
+        /// <param name="error">错误码</param>
+        /// <param name="message">错误消息</param>
+        /// <param name="actorId">房间的ActorId</param>
+        /// <param name="isFromPool"></param>
+        public static Map2Match_GetRoom Create(int error = default, string message = default, ActorId actorId = default, bool isFromPool = false)
+        {
+            Map2Match_GetRoom msg = ObjectPool.Instance.Fetch(typeof(Map2Match_GetRoom), isFromPool) as Map2Match_GetRoom;
+            msg.Set(error, message, actorId);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set Map2Match_GetRoom
+        /// </summary>
+        /// <param name="error">错误码</param>
+        /// <param name="message">错误消息</param>
+        /// <param name="actorId">房间的ActorId</param>
+        public void Set(int error = default, string message = default, ActorId actorId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.ActorId = actorId;
+        }
 
         public override void Dispose()
         {
@@ -144,16 +181,23 @@ namespace ET
     [ResponseType(nameof(Room2G_Reconnect))]
     public partial class G2Room_Reconnect : MessageObject, IRequest
     {
-        public static G2Room_Reconnect Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2Room_Reconnect), isFromPool) as G2Room_Reconnect;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public long PlayerId { get; set; }
+
+        public static G2Room_Reconnect Create(long playerId = default, bool isFromPool = false)
+        {
+            G2Room_Reconnect msg = ObjectPool.Instance.Fetch(typeof(G2Room_Reconnect), isFromPool) as G2Room_Reconnect;
+            msg.Set(playerId);
+            return msg;
+        }
+
+        public void Set(long playerId = default)
+        {
+            this.PlayerId = playerId;
+        }
 
         public override void Dispose()
         {
@@ -173,11 +217,6 @@ namespace ET
     [Message(LockStepInner.Room2G_Reconnect)]
     public partial class Room2G_Reconnect : MessageObject, IResponse
     {
-        public static Room2G_Reconnect Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Room2G_Reconnect), isFromPool) as Room2G_Reconnect;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -195,6 +234,21 @@ namespace ET
 
         [MemoryPackOrder(5)]
         public int Frame { get; set; }
+
+        public static Room2G_Reconnect Create(int error = default, string message = default, long startTime = default, int frame = default, bool isFromPool = false)
+        {
+            Room2G_Reconnect msg = ObjectPool.Instance.Fetch(typeof(Room2G_Reconnect), isFromPool) as Room2G_Reconnect;
+            msg.Set(error, message, startTime, frame);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, long startTime = default, int frame = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.StartTime = startTime;
+            this.Frame = frame;
+        }
 
         public override void Dispose()
         {
@@ -219,16 +273,16 @@ namespace ET
     [ResponseType(nameof(Room2RoomManager_Init))]
     public partial class RoomManager2Room_Init : MessageObject, IRequest
     {
-        public static RoomManager2Room_Init Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(RoomManager2Room_Init), isFromPool) as RoomManager2Room_Init;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public List<long> PlayerIds { get; set; } = new();
+
+        public static RoomManager2Room_Init Create(bool isFromPool = false)
+        {
+            return ObjectPool.Instance.Fetch(typeof(RoomManager2Room_Init), isFromPool) as RoomManager2Room_Init;
+        }
 
         public override void Dispose()
         {
@@ -248,11 +302,6 @@ namespace ET
     [Message(LockStepInner.Room2RoomManager_Init)]
     public partial class Room2RoomManager_Init : MessageObject, IResponse
     {
-        public static Room2RoomManager_Init Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Room2RoomManager_Init), isFromPool) as Room2RoomManager_Init;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -261,6 +310,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static Room2RoomManager_Init Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            Room2RoomManager_Init msg = ObjectPool.Instance.Fetch(typeof(Room2RoomManager_Init), isFromPool) as Room2RoomManager_Init;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {

--- a/Unity/Assets/Scripts/Model/Generate/ClientServer/Message/LockStepOuter_C_11001.cs
+++ b/Unity/Assets/Scripts/Model/Generate/ClientServer/Message/LockStepOuter_C_11001.cs
@@ -8,13 +8,13 @@ namespace ET
     [ResponseType(nameof(G2C_Match))]
     public partial class C2G_Match : MessageObject, ISessionRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2G_Match Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2G_Match), isFromPool) as C2G_Match;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -33,11 +33,6 @@ namespace ET
     [Message(LockStepOuter.G2C_Match)]
     public partial class G2C_Match : MessageObject, ISessionResponse
     {
-        public static G2C_Match Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_Match), isFromPool) as G2C_Match;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -46,6 +41,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static G2C_Match Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            G2C_Match msg = ObjectPool.Instance.Fetch(typeof(G2C_Match), isFromPool) as G2C_Match;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -69,11 +77,6 @@ namespace ET
     [Message(LockStepOuter.Match2G_NotifyMatchSuccess)]
     public partial class Match2G_NotifyMatchSuccess : MessageObject, IMessage
     {
-        public static Match2G_NotifyMatchSuccess Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Match2G_NotifyMatchSuccess), isFromPool) as Match2G_NotifyMatchSuccess;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -82,6 +85,30 @@ namespace ET
         /// </summary>
         [MemoryPackOrder(1)]
         public ActorId ActorId { get; set; }
+
+        /// <summary>
+        /// Create Match2G_NotifyMatchSuccess
+        /// </summary>
+        /// <param name="rpcId">RpcId</param>
+        /// <param name="actorId">房间的ActorId</param>
+        /// <param name="isFromPool"></param>
+        public static Match2G_NotifyMatchSuccess Create(int rpcId = default, ActorId actorId = default, bool isFromPool = false)
+        {
+            Match2G_NotifyMatchSuccess msg = ObjectPool.Instance.Fetch(typeof(Match2G_NotifyMatchSuccess), isFromPool) as Match2G_NotifyMatchSuccess;
+            msg.Set(rpcId, actorId);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set Match2G_NotifyMatchSuccess
+        /// </summary>
+        /// <param name="rpcId">RpcId</param>
+        /// <param name="actorId">房间的ActorId</param>
+        public void Set(int rpcId = default, ActorId actorId = default)
+        {
+            this.RpcId = rpcId;
+            this.ActorId = actorId;
+        }
 
         public override void Dispose()
         {
@@ -104,13 +131,20 @@ namespace ET
     [Message(LockStepOuter.C2Room_ChangeSceneFinish)]
     public partial class C2Room_ChangeSceneFinish : MessageObject, IRoomMessage
     {
-        public static C2Room_ChangeSceneFinish Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2Room_ChangeSceneFinish), isFromPool) as C2Room_ChangeSceneFinish;
-        }
-
         [MemoryPackOrder(0)]
         public long PlayerId { get; set; }
+
+        public static C2Room_ChangeSceneFinish Create(long playerId = default, bool isFromPool = false)
+        {
+            C2Room_ChangeSceneFinish msg = ObjectPool.Instance.Fetch(typeof(C2Room_ChangeSceneFinish), isFromPool) as C2Room_ChangeSceneFinish;
+            msg.Set(playerId);
+            return msg;
+        }
+
+        public void Set(long playerId = default)
+        {
+            this.PlayerId = playerId;
+        }
 
         public override void Dispose()
         {
@@ -129,11 +163,6 @@ namespace ET
     [Message(LockStepOuter.LockStepUnitInfo)]
     public partial class LockStepUnitInfo : MessageObject
     {
-        public static LockStepUnitInfo Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(LockStepUnitInfo), isFromPool) as LockStepUnitInfo;
-        }
-
         [MemoryPackOrder(0)]
         public long PlayerId { get; set; }
 
@@ -142,6 +171,20 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public TrueSync.TSQuaternion Rotation { get; set; }
+
+        public static LockStepUnitInfo Create(long playerId = default, TrueSync.TSVector position = default, TrueSync.TSQuaternion rotation = default, bool isFromPool = false)
+        {
+            LockStepUnitInfo msg = ObjectPool.Instance.Fetch(typeof(LockStepUnitInfo), isFromPool) as LockStepUnitInfo;
+            msg.Set(playerId, position, rotation);
+            return msg;
+        }
+
+        public void Set(long playerId = default, TrueSync.TSVector position = default, TrueSync.TSQuaternion rotation = default)
+        {
+            this.PlayerId = playerId;
+            this.Position = position;
+            this.Rotation = rotation;
+        }
 
         public override void Dispose()
         {
@@ -165,16 +208,23 @@ namespace ET
     [Message(LockStepOuter.Room2C_Start)]
     public partial class Room2C_Start : MessageObject, IMessage
     {
-        public static Room2C_Start Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Room2C_Start), isFromPool) as Room2C_Start;
-        }
-
         [MemoryPackOrder(0)]
         public long StartTime { get; set; }
 
         [MemoryPackOrder(1)]
         public List<LockStepUnitInfo> UnitInfo { get; set; } = new();
+
+        public static Room2C_Start Create(long startTime = default, bool isFromPool = false)
+        {
+            Room2C_Start msg = ObjectPool.Instance.Fetch(typeof(Room2C_Start), isFromPool) as Room2C_Start;
+            msg.Set(startTime);
+            return msg;
+        }
+
+        public void Set(long startTime = default)
+        {
+            this.StartTime = startTime;
+        }
 
         public override void Dispose()
         {
@@ -194,11 +244,6 @@ namespace ET
     [Message(LockStepOuter.FrameMessage)]
     public partial class FrameMessage : MessageObject, IMessage
     {
-        public static FrameMessage Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(FrameMessage), isFromPool) as FrameMessage;
-        }
-
         [MemoryPackOrder(0)]
         public int Frame { get; set; }
 
@@ -207,6 +252,20 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public LSInput Input { get; set; }
+
+        public static FrameMessage Create(int frame = default, long playerId = default, LSInput input = default, bool isFromPool = false)
+        {
+            FrameMessage msg = ObjectPool.Instance.Fetch(typeof(FrameMessage), isFromPool) as FrameMessage;
+            msg.Set(frame, playerId, input);
+            return msg;
+        }
+
+        public void Set(int frame = default, long playerId = default, LSInput input = default)
+        {
+            this.Frame = frame;
+            this.PlayerId = playerId;
+            this.Input = input;
+        }
 
         public override void Dispose()
         {
@@ -227,14 +286,15 @@ namespace ET
     [Message(LockStepOuter.OneFrameInputs)]
     public partial class OneFrameInputs : MessageObject, IMessage
     {
+        [MongoDB.Bson.Serialization.Attributes.BsonDictionaryOptions(MongoDB.Bson.Serialization.Options.DictionaryRepresentation.ArrayOfArrays)]
+        [MemoryPackOrder(1)]
+        public Dictionary<long, LSInput> Inputs { get; set; } = new();
+
         public static OneFrameInputs Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(OneFrameInputs), isFromPool) as OneFrameInputs;
         }
 
-        [MongoDB.Bson.Serialization.Attributes.BsonDictionaryOptions(MongoDB.Bson.Serialization.Options.DictionaryRepresentation.ArrayOfArrays)]
-        [MemoryPackOrder(1)]
-        public Dictionary<long, LSInput> Inputs { get; set; } = new();
         public override void Dispose()
         {
             if (!this.IsFromPool)
@@ -252,13 +312,20 @@ namespace ET
     [Message(LockStepOuter.Room2C_AdjustUpdateTime)]
     public partial class Room2C_AdjustUpdateTime : MessageObject, IMessage
     {
-        public static Room2C_AdjustUpdateTime Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Room2C_AdjustUpdateTime), isFromPool) as Room2C_AdjustUpdateTime;
-        }
-
         [MemoryPackOrder(0)]
         public int DiffTime { get; set; }
+
+        public static Room2C_AdjustUpdateTime Create(int diffTime = default, bool isFromPool = false)
+        {
+            Room2C_AdjustUpdateTime msg = ObjectPool.Instance.Fetch(typeof(Room2C_AdjustUpdateTime), isFromPool) as Room2C_AdjustUpdateTime;
+            msg.Set(diffTime);
+            return msg;
+        }
+
+        public void Set(int diffTime = default)
+        {
+            this.DiffTime = diffTime;
+        }
 
         public override void Dispose()
         {
@@ -277,11 +344,6 @@ namespace ET
     [Message(LockStepOuter.C2Room_CheckHash)]
     public partial class C2Room_CheckHash : MessageObject, IRoomMessage
     {
-        public static C2Room_CheckHash Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2Room_CheckHash), isFromPool) as C2Room_CheckHash;
-        }
-
         [MemoryPackOrder(0)]
         public long PlayerId { get; set; }
 
@@ -290,6 +352,20 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public long Hash { get; set; }
+
+        public static C2Room_CheckHash Create(long playerId = default, int frame = default, long hash = default, bool isFromPool = false)
+        {
+            C2Room_CheckHash msg = ObjectPool.Instance.Fetch(typeof(C2Room_CheckHash), isFromPool) as C2Room_CheckHash;
+            msg.Set(playerId, frame, hash);
+            return msg;
+        }
+
+        public void Set(long playerId = default, int frame = default, long hash = default)
+        {
+            this.PlayerId = playerId;
+            this.Frame = frame;
+            this.Hash = hash;
+        }
 
         public override void Dispose()
         {
@@ -310,16 +386,24 @@ namespace ET
     [Message(LockStepOuter.Room2C_CheckHashFail)]
     public partial class Room2C_CheckHashFail : MessageObject, IMessage
     {
-        public static Room2C_CheckHashFail Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Room2C_CheckHashFail), isFromPool) as Room2C_CheckHashFail;
-        }
-
         [MemoryPackOrder(0)]
         public int Frame { get; set; }
 
         [MemoryPackOrder(1)]
         public byte[] LSWorldBytes { get; set; }
+
+        public static Room2C_CheckHashFail Create(int frame = default, byte[] lSWorldBytes = default, bool isFromPool = false)
+        {
+            Room2C_CheckHashFail msg = ObjectPool.Instance.Fetch(typeof(Room2C_CheckHashFail), isFromPool) as Room2C_CheckHashFail;
+            msg.Set(frame, lSWorldBytes);
+            return msg;
+        }
+
+        public void Set(int frame = default, byte[] lSWorldBytes = default)
+        {
+            this.Frame = frame;
+            this.LSWorldBytes = lSWorldBytes;
+        }
 
         public override void Dispose()
         {
@@ -339,11 +423,6 @@ namespace ET
     [Message(LockStepOuter.G2C_Reconnect)]
     public partial class G2C_Reconnect : MessageObject, IMessage
     {
-        public static G2C_Reconnect Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_Reconnect), isFromPool) as G2C_Reconnect;
-        }
-
         [MemoryPackOrder(0)]
         public long StartTime { get; set; }
 
@@ -352,6 +431,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public int Frame { get; set; }
+
+        public static G2C_Reconnect Create(long startTime = default, int frame = default, bool isFromPool = false)
+        {
+            G2C_Reconnect msg = ObjectPool.Instance.Fetch(typeof(G2C_Reconnect), isFromPool) as G2C_Reconnect;
+            msg.Set(startTime, frame);
+            return msg;
+        }
+
+        public void Set(long startTime = default, int frame = default)
+        {
+            this.StartTime = startTime;
+            this.Frame = frame;
+        }
 
         public override void Dispose()
         {

--- a/Unity/Assets/Scripts/Model/Generate/ClientServer/Message/OuterMessage_C_10001.cs
+++ b/Unity/Assets/Scripts/Model/Generate/ClientServer/Message/OuterMessage_C_10001.cs
@@ -7,16 +7,16 @@ namespace ET
     [Message(OuterMessage.HttpGetRouterResponse)]
     public partial class HttpGetRouterResponse : MessageObject
     {
-        public static HttpGetRouterResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(HttpGetRouterResponse), isFromPool) as HttpGetRouterResponse;
-        }
-
         [MemoryPackOrder(0)]
         public List<string> Realms { get; set; } = new();
 
         [MemoryPackOrder(1)]
         public List<string> Routers { get; set; } = new();
+
+        public static HttpGetRouterResponse Create(bool isFromPool = false)
+        {
+            return ObjectPool.Instance.Fetch(typeof(HttpGetRouterResponse), isFromPool) as HttpGetRouterResponse;
+        }
 
         public override void Dispose()
         {
@@ -36,16 +36,24 @@ namespace ET
     [Message(OuterMessage.RouterSync)]
     public partial class RouterSync : MessageObject
     {
-        public static RouterSync Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(RouterSync), isFromPool) as RouterSync;
-        }
-
         [MemoryPackOrder(0)]
         public uint ConnectId { get; set; }
 
         [MemoryPackOrder(1)]
         public string Address { get; set; }
+
+        public static RouterSync Create(uint connectId = default, string address = default, bool isFromPool = false)
+        {
+            RouterSync msg = ObjectPool.Instance.Fetch(typeof(RouterSync), isFromPool) as RouterSync;
+            msg.Set(connectId, address);
+            return msg;
+        }
+
+        public void Set(uint connectId = default, string address = default)
+        {
+            this.ConnectId = connectId;
+            this.Address = address;
+        }
 
         public override void Dispose()
         {
@@ -66,16 +74,23 @@ namespace ET
     [ResponseType(nameof(M2C_TestResponse))]
     public partial class C2M_TestRequest : MessageObject, ILocationRequest
     {
-        public static C2M_TestRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_TestRequest), isFromPool) as C2M_TestRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public string request { get; set; }
+
+        public static C2M_TestRequest Create(string request = default, bool isFromPool = false)
+        {
+            C2M_TestRequest msg = ObjectPool.Instance.Fetch(typeof(C2M_TestRequest), isFromPool) as C2M_TestRequest;
+            msg.Set(request);
+            return msg;
+        }
+
+        public void Set(string request = default)
+        {
+            this.request = request;
+        }
 
         public override void Dispose()
         {
@@ -95,11 +110,6 @@ namespace ET
     [Message(OuterMessage.M2C_TestResponse)]
     public partial class M2C_TestResponse : MessageObject, IResponse
     {
-        public static M2C_TestResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_TestResponse), isFromPool) as M2C_TestResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -111,6 +121,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public string response { get; set; }
+
+        public static M2C_TestResponse Create(int error = default, string message = default, string response = default, bool isFromPool = false)
+        {
+            M2C_TestResponse msg = ObjectPool.Instance.Fetch(typeof(M2C_TestResponse), isFromPool) as M2C_TestResponse;
+            msg.Set(error, message, response);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, string response = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.response = response;
+        }
 
         public override void Dispose()
         {
@@ -133,13 +157,13 @@ namespace ET
     [ResponseType(nameof(G2C_EnterMap))]
     public partial class C2G_EnterMap : MessageObject, ISessionRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2G_EnterMap Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2G_EnterMap), isFromPool) as C2G_EnterMap;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -158,11 +182,6 @@ namespace ET
     [Message(OuterMessage.G2C_EnterMap)]
     public partial class G2C_EnterMap : MessageObject, ISessionResponse
     {
-        public static G2C_EnterMap Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_EnterMap), isFromPool) as G2C_EnterMap;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -177,6 +196,33 @@ namespace ET
         /// </summary>
         [MemoryPackOrder(3)]
         public long MyId { get; set; }
+
+        /// <summary>
+        /// Create G2C_EnterMap
+        /// </summary>
+        /// <param name="error">错误码</param>
+        /// <param name="message">错误消息</param>
+        /// <param name="myId">自己的UnitId</param>
+        /// <param name="isFromPool"></param>
+        public static G2C_EnterMap Create(int error = default, string message = default, long myId = default, bool isFromPool = false)
+        {
+            G2C_EnterMap msg = ObjectPool.Instance.Fetch(typeof(G2C_EnterMap), isFromPool) as G2C_EnterMap;
+            msg.Set(error, message, myId);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set G2C_EnterMap
+        /// </summary>
+        /// <param name="error">错误码</param>
+        /// <param name="message">错误消息</param>
+        /// <param name="myId">自己的UnitId</param>
+        public void Set(int error = default, string message = default, long myId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.MyId = myId;
+        }
 
         public override void Dispose()
         {
@@ -198,11 +244,6 @@ namespace ET
     [Message(OuterMessage.MoveInfo)]
     public partial class MoveInfo : MessageObject
     {
-        public static MoveInfo Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(MoveInfo), isFromPool) as MoveInfo;
-        }
-
         [MemoryPackOrder(0)]
         public List<Unity.Mathematics.float3> Points { get; set; } = new();
 
@@ -211,6 +252,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public int TurnSpeed { get; set; }
+
+        public static MoveInfo Create(Unity.Mathematics.quaternion rotation = default, int turnSpeed = default, bool isFromPool = false)
+        {
+            MoveInfo msg = ObjectPool.Instance.Fetch(typeof(MoveInfo), isFromPool) as MoveInfo;
+            msg.Set(rotation, turnSpeed);
+            return msg;
+        }
+
+        public void Set(Unity.Mathematics.quaternion rotation = default, int turnSpeed = default)
+        {
+            this.Rotation = rotation;
+            this.TurnSpeed = turnSpeed;
+        }
 
         public override void Dispose()
         {
@@ -231,11 +285,6 @@ namespace ET
     [Message(OuterMessage.UnitInfo)]
     public partial class UnitInfo : MessageObject
     {
-        public static UnitInfo Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(UnitInfo), isFromPool) as UnitInfo;
-        }
-
         [MemoryPackOrder(0)]
         public long UnitId { get; set; }
 
@@ -254,8 +303,26 @@ namespace ET
         [MongoDB.Bson.Serialization.Attributes.BsonDictionaryOptions(MongoDB.Bson.Serialization.Options.DictionaryRepresentation.ArrayOfArrays)]
         [MemoryPackOrder(5)]
         public Dictionary<int, long> KV { get; set; } = new();
+
         [MemoryPackOrder(6)]
         public MoveInfo MoveInfo { get; set; }
+
+        public static UnitInfo Create(long unitId = default, int configId = default, int type = default, Unity.Mathematics.float3 position = default, Unity.Mathematics.float3 forward = default, MoveInfo moveInfo = default, bool isFromPool = false)
+        {
+            UnitInfo msg = ObjectPool.Instance.Fetch(typeof(UnitInfo), isFromPool) as UnitInfo;
+            msg.Set(unitId, configId, type, position, forward, moveInfo);
+            return msg;
+        }
+
+        public void Set(long unitId = default, int configId = default, int type = default, Unity.Mathematics.float3 position = default, Unity.Mathematics.float3 forward = default, MoveInfo moveInfo = default)
+        {
+            this.UnitId = unitId;
+            this.ConfigId = configId;
+            this.Type = type;
+            this.Position = position;
+            this.Forward = forward;
+            this.MoveInfo = moveInfo;
+        }
 
         public override void Dispose()
         {
@@ -280,13 +347,13 @@ namespace ET
     [Message(OuterMessage.M2C_CreateUnits)]
     public partial class M2C_CreateUnits : MessageObject, IMessage
     {
+        [MemoryPackOrder(0)]
+        public List<UnitInfo> Units { get; set; } = new();
+
         public static M2C_CreateUnits Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(M2C_CreateUnits), isFromPool) as M2C_CreateUnits;
         }
-
-        [MemoryPackOrder(0)]
-        public List<UnitInfo> Units { get; set; } = new();
 
         public override void Dispose()
         {
@@ -305,13 +372,20 @@ namespace ET
     [Message(OuterMessage.M2C_CreateMyUnit)]
     public partial class M2C_CreateMyUnit : MessageObject, IMessage
     {
-        public static M2C_CreateMyUnit Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_CreateMyUnit), isFromPool) as M2C_CreateMyUnit;
-        }
-
         [MemoryPackOrder(0)]
         public UnitInfo Unit { get; set; }
+
+        public static M2C_CreateMyUnit Create(UnitInfo unit = default, bool isFromPool = false)
+        {
+            M2C_CreateMyUnit msg = ObjectPool.Instance.Fetch(typeof(M2C_CreateMyUnit), isFromPool) as M2C_CreateMyUnit;
+            msg.Set(unit);
+            return msg;
+        }
+
+        public void Set(UnitInfo unit = default)
+        {
+            this.Unit = unit;
+        }
 
         public override void Dispose()
         {
@@ -330,16 +404,24 @@ namespace ET
     [Message(OuterMessage.M2C_StartSceneChange)]
     public partial class M2C_StartSceneChange : MessageObject, IMessage
     {
-        public static M2C_StartSceneChange Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_StartSceneChange), isFromPool) as M2C_StartSceneChange;
-        }
-
         [MemoryPackOrder(0)]
         public long SceneInstanceId { get; set; }
 
         [MemoryPackOrder(1)]
         public string SceneName { get; set; }
+
+        public static M2C_StartSceneChange Create(long sceneInstanceId = default, string sceneName = default, bool isFromPool = false)
+        {
+            M2C_StartSceneChange msg = ObjectPool.Instance.Fetch(typeof(M2C_StartSceneChange), isFromPool) as M2C_StartSceneChange;
+            msg.Set(sceneInstanceId, sceneName);
+            return msg;
+        }
+
+        public void Set(long sceneInstanceId = default, string sceneName = default)
+        {
+            this.SceneInstanceId = sceneInstanceId;
+            this.SceneName = sceneName;
+        }
 
         public override void Dispose()
         {
@@ -359,13 +441,13 @@ namespace ET
     [Message(OuterMessage.M2C_RemoveUnits)]
     public partial class M2C_RemoveUnits : MessageObject, IMessage
     {
+        [MemoryPackOrder(0)]
+        public List<long> Units { get; set; } = new();
+
         public static M2C_RemoveUnits Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(M2C_RemoveUnits), isFromPool) as M2C_RemoveUnits;
         }
-
-        [MemoryPackOrder(0)]
-        public List<long> Units { get; set; } = new();
 
         public override void Dispose()
         {
@@ -384,16 +466,23 @@ namespace ET
     [Message(OuterMessage.C2M_PathfindingResult)]
     public partial class C2M_PathfindingResult : MessageObject, ILocationMessage
     {
-        public static C2M_PathfindingResult Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_PathfindingResult), isFromPool) as C2M_PathfindingResult;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public Unity.Mathematics.float3 Position { get; set; }
+
+        public static C2M_PathfindingResult Create(Unity.Mathematics.float3 position = default, bool isFromPool = false)
+        {
+            C2M_PathfindingResult msg = ObjectPool.Instance.Fetch(typeof(C2M_PathfindingResult), isFromPool) as C2M_PathfindingResult;
+            msg.Set(position);
+            return msg;
+        }
+
+        public void Set(Unity.Mathematics.float3 position = default)
+        {
+            this.Position = position;
+        }
 
         public override void Dispose()
         {
@@ -413,13 +502,13 @@ namespace ET
     [Message(OuterMessage.C2M_Stop)]
     public partial class C2M_Stop : MessageObject, ILocationMessage
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2M_Stop Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2M_Stop), isFromPool) as C2M_Stop;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -438,11 +527,6 @@ namespace ET
     [Message(OuterMessage.M2C_PathfindingResult)]
     public partial class M2C_PathfindingResult : MessageObject, IMessage
     {
-        public static M2C_PathfindingResult Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_PathfindingResult), isFromPool) as M2C_PathfindingResult;
-        }
-
         [MemoryPackOrder(0)]
         public long Id { get; set; }
 
@@ -451,6 +535,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public List<Unity.Mathematics.float3> Points { get; set; } = new();
+
+        public static M2C_PathfindingResult Create(long id = default, Unity.Mathematics.float3 position = default, bool isFromPool = false)
+        {
+            M2C_PathfindingResult msg = ObjectPool.Instance.Fetch(typeof(M2C_PathfindingResult), isFromPool) as M2C_PathfindingResult;
+            msg.Set(id, position);
+            return msg;
+        }
+
+        public void Set(long id = default, Unity.Mathematics.float3 position = default)
+        {
+            this.Id = id;
+            this.Position = position;
+        }
 
         public override void Dispose()
         {
@@ -471,11 +568,6 @@ namespace ET
     [Message(OuterMessage.M2C_Stop)]
     public partial class M2C_Stop : MessageObject, IMessage
     {
-        public static M2C_Stop Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_Stop), isFromPool) as M2C_Stop;
-        }
-
         [MemoryPackOrder(0)]
         public int Error { get; set; }
 
@@ -487,6 +579,21 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public Unity.Mathematics.quaternion Rotation { get; set; }
+
+        public static M2C_Stop Create(int error = default, long id = default, Unity.Mathematics.float3 position = default, Unity.Mathematics.quaternion rotation = default, bool isFromPool = false)
+        {
+            M2C_Stop msg = ObjectPool.Instance.Fetch(typeof(M2C_Stop), isFromPool) as M2C_Stop;
+            msg.Set(error, id, position, rotation);
+            return msg;
+        }
+
+        public void Set(int error = default, long id = default, Unity.Mathematics.float3 position = default, Unity.Mathematics.quaternion rotation = default)
+        {
+            this.Error = error;
+            this.Id = id;
+            this.Position = position;
+            this.Rotation = rotation;
+        }
 
         public override void Dispose()
         {
@@ -509,13 +616,13 @@ namespace ET
     [ResponseType(nameof(G2C_Ping))]
     public partial class C2G_Ping : MessageObject, ISessionRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2G_Ping Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2G_Ping), isFromPool) as C2G_Ping;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -534,11 +641,6 @@ namespace ET
     [Message(OuterMessage.G2C_Ping)]
     public partial class G2C_Ping : MessageObject, ISessionResponse
     {
-        public static G2C_Ping Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_Ping), isFromPool) as G2C_Ping;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -550,6 +652,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public long Time { get; set; }
+
+        public static G2C_Ping Create(int error = default, string message = default, long time = default, bool isFromPool = false)
+        {
+            G2C_Ping msg = ObjectPool.Instance.Fetch(typeof(G2C_Ping), isFromPool) as G2C_Ping;
+            msg.Set(error, message, time);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, long time = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.Time = time;
+        }
 
         public override void Dispose()
         {
@@ -583,7 +699,6 @@ namespace ET
                 return;
             }
 
-            
             ObjectPool.Instance.Recycle(this);
         }
     }
@@ -593,11 +708,6 @@ namespace ET
     [ResponseType(nameof(M2C_Reload))]
     public partial class C2M_Reload : MessageObject, ISessionRequest
     {
-        public static C2M_Reload Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_Reload), isFromPool) as C2M_Reload;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -606,6 +716,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Password { get; set; }
+
+        public static C2M_Reload Create(string account = default, string password = default, bool isFromPool = false)
+        {
+            C2M_Reload msg = ObjectPool.Instance.Fetch(typeof(C2M_Reload), isFromPool) as C2M_Reload;
+            msg.Set(account, password);
+            return msg;
+        }
+
+        public void Set(string account = default, string password = default)
+        {
+            this.Account = account;
+            this.Password = password;
+        }
 
         public override void Dispose()
         {
@@ -626,11 +749,6 @@ namespace ET
     [Message(OuterMessage.M2C_Reload)]
     public partial class M2C_Reload : MessageObject, ISessionResponse
     {
-        public static M2C_Reload Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_Reload), isFromPool) as M2C_Reload;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -639,6 +757,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static M2C_Reload Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            M2C_Reload msg = ObjectPool.Instance.Fetch(typeof(M2C_Reload), isFromPool) as M2C_Reload;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -660,11 +791,6 @@ namespace ET
     [ResponseType(nameof(R2C_Login))]
     public partial class C2R_Login : MessageObject, ISessionRequest
     {
-        public static C2R_Login Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2R_Login), isFromPool) as C2R_Login;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -679,6 +805,30 @@ namespace ET
         /// </summary>
         [MemoryPackOrder(2)]
         public string Password { get; set; }
+
+        /// <summary>
+        /// Create C2R_Login
+        /// </summary>
+        /// <param name="account">帐号</param>
+        /// <param name="password">密码</param>
+        /// <param name="isFromPool"></param>
+        public static C2R_Login Create(string account = default, string password = default, bool isFromPool = false)
+        {
+            C2R_Login msg = ObjectPool.Instance.Fetch(typeof(C2R_Login), isFromPool) as C2R_Login;
+            msg.Set(account, password);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set C2R_Login
+        /// </summary>
+        /// <param name="account">帐号</param>
+        /// <param name="password">密码</param>
+        public void Set(string account = default, string password = default)
+        {
+            this.Account = account;
+            this.Password = password;
+        }
 
         public override void Dispose()
         {
@@ -699,11 +849,6 @@ namespace ET
     [Message(OuterMessage.R2C_Login)]
     public partial class R2C_Login : MessageObject, ISessionResponse
     {
-        public static R2C_Login Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(R2C_Login), isFromPool) as R2C_Login;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -721,6 +866,22 @@ namespace ET
 
         [MemoryPackOrder(5)]
         public long GateId { get; set; }
+
+        public static R2C_Login Create(int error = default, string message = default, string address = default, long key = default, long gateId = default, bool isFromPool = false)
+        {
+            R2C_Login msg = ObjectPool.Instance.Fetch(typeof(R2C_Login), isFromPool) as R2C_Login;
+            msg.Set(error, message, address, key, gateId);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, string address = default, long key = default, long gateId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.Address = address;
+            this.Key = key;
+            this.GateId = gateId;
+        }
 
         public override void Dispose()
         {
@@ -745,11 +906,6 @@ namespace ET
     [ResponseType(nameof(G2C_LoginGate))]
     public partial class C2G_LoginGate : MessageObject, ISessionRequest
     {
-        public static C2G_LoginGate Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2G_LoginGate), isFromPool) as C2G_LoginGate;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -761,6 +917,30 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public long GateId { get; set; }
+
+        /// <summary>
+        /// Create C2G_LoginGate
+        /// </summary>
+        /// <param name="key">帐号</param>
+        /// <param name="gateId">GateId</param>
+        /// <param name="isFromPool"></param>
+        public static C2G_LoginGate Create(long key = default, long gateId = default, bool isFromPool = false)
+        {
+            C2G_LoginGate msg = ObjectPool.Instance.Fetch(typeof(C2G_LoginGate), isFromPool) as C2G_LoginGate;
+            msg.Set(key, gateId);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set C2G_LoginGate
+        /// </summary>
+        /// <param name="key">帐号</param>
+        /// <param name="gateId">GateId</param>
+        public void Set(long key = default, long gateId = default)
+        {
+            this.Key = key;
+            this.GateId = gateId;
+        }
 
         public override void Dispose()
         {
@@ -781,11 +961,6 @@ namespace ET
     [Message(OuterMessage.G2C_LoginGate)]
     public partial class G2C_LoginGate : MessageObject, ISessionResponse
     {
-        public static G2C_LoginGate Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_LoginGate), isFromPool) as G2C_LoginGate;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -797,6 +972,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public long PlayerId { get; set; }
+
+        public static G2C_LoginGate Create(int error = default, string message = default, long playerId = default, bool isFromPool = false)
+        {
+            G2C_LoginGate msg = ObjectPool.Instance.Fetch(typeof(G2C_LoginGate), isFromPool) as G2C_LoginGate;
+            msg.Set(error, message, playerId);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, long playerId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.PlayerId = playerId;
+        }
 
         public override void Dispose()
         {
@@ -818,13 +1007,20 @@ namespace ET
     [Message(OuterMessage.G2C_TestHotfixMessage)]
     public partial class G2C_TestHotfixMessage : MessageObject, ISessionMessage
     {
-        public static G2C_TestHotfixMessage Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_TestHotfixMessage), isFromPool) as G2C_TestHotfixMessage;
-        }
-
         [MemoryPackOrder(0)]
         public string Info { get; set; }
+
+        public static G2C_TestHotfixMessage Create(string info = default, bool isFromPool = false)
+        {
+            G2C_TestHotfixMessage msg = ObjectPool.Instance.Fetch(typeof(G2C_TestHotfixMessage), isFromPool) as G2C_TestHotfixMessage;
+            msg.Set(info);
+            return msg;
+        }
+
+        public void Set(string info = default)
+        {
+            this.Info = info;
+        }
 
         public override void Dispose()
         {
@@ -844,16 +1040,23 @@ namespace ET
     [ResponseType(nameof(M2C_TestRobotCase))]
     public partial class C2M_TestRobotCase : MessageObject, ILocationRequest
     {
-        public static C2M_TestRobotCase Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_TestRobotCase), isFromPool) as C2M_TestRobotCase;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public int N { get; set; }
+
+        public static C2M_TestRobotCase Create(int n = default, bool isFromPool = false)
+        {
+            C2M_TestRobotCase msg = ObjectPool.Instance.Fetch(typeof(C2M_TestRobotCase), isFromPool) as C2M_TestRobotCase;
+            msg.Set(n);
+            return msg;
+        }
+
+        public void Set(int n = default)
+        {
+            this.N = n;
+        }
 
         public override void Dispose()
         {
@@ -873,11 +1076,6 @@ namespace ET
     [Message(OuterMessage.M2C_TestRobotCase)]
     public partial class M2C_TestRobotCase : MessageObject, ILocationResponse
     {
-        public static M2C_TestRobotCase Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_TestRobotCase), isFromPool) as M2C_TestRobotCase;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -889,6 +1087,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public int N { get; set; }
+
+        public static M2C_TestRobotCase Create(int error = default, string message = default, int n = default, bool isFromPool = false)
+        {
+            M2C_TestRobotCase msg = ObjectPool.Instance.Fetch(typeof(M2C_TestRobotCase), isFromPool) as M2C_TestRobotCase;
+            msg.Set(error, message, n);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, int n = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.N = n;
+        }
 
         public override void Dispose()
         {
@@ -910,16 +1122,23 @@ namespace ET
     [Message(OuterMessage.C2M_TestRobotCase2)]
     public partial class C2M_TestRobotCase2 : MessageObject, ILocationMessage
     {
-        public static C2M_TestRobotCase2 Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_TestRobotCase2), isFromPool) as C2M_TestRobotCase2;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public int N { get; set; }
+
+        public static C2M_TestRobotCase2 Create(int n = default, bool isFromPool = false)
+        {
+            C2M_TestRobotCase2 msg = ObjectPool.Instance.Fetch(typeof(C2M_TestRobotCase2), isFromPool) as C2M_TestRobotCase2;
+            msg.Set(n);
+            return msg;
+        }
+
+        public void Set(int n = default)
+        {
+            this.N = n;
+        }
 
         public override void Dispose()
         {
@@ -939,16 +1158,23 @@ namespace ET
     [Message(OuterMessage.M2C_TestRobotCase2)]
     public partial class M2C_TestRobotCase2 : MessageObject, ILocationMessage
     {
-        public static M2C_TestRobotCase2 Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_TestRobotCase2), isFromPool) as M2C_TestRobotCase2;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public int N { get; set; }
+
+        public static M2C_TestRobotCase2 Create(int n = default, bool isFromPool = false)
+        {
+            M2C_TestRobotCase2 msg = ObjectPool.Instance.Fetch(typeof(M2C_TestRobotCase2), isFromPool) as M2C_TestRobotCase2;
+            msg.Set(n);
+            return msg;
+        }
+
+        public void Set(int n = default)
+        {
+            this.N = n;
+        }
 
         public override void Dispose()
         {
@@ -969,13 +1195,13 @@ namespace ET
     [ResponseType(nameof(M2C_TransferMap))]
     public partial class C2M_TransferMap : MessageObject, ILocationRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2M_TransferMap Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2M_TransferMap), isFromPool) as C2M_TransferMap;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -994,11 +1220,6 @@ namespace ET
     [Message(OuterMessage.M2C_TransferMap)]
     public partial class M2C_TransferMap : MessageObject, ILocationResponse
     {
-        public static M2C_TransferMap Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_TransferMap), isFromPool) as M2C_TransferMap;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -1007,6 +1228,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static M2C_TransferMap Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            M2C_TransferMap msg = ObjectPool.Instance.Fetch(typeof(M2C_TransferMap), isFromPool) as M2C_TransferMap;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -1028,13 +1262,13 @@ namespace ET
     [ResponseType(nameof(G2C_Benchmark))]
     public partial class C2G_Benchmark : MessageObject, ISessionRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2G_Benchmark Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2G_Benchmark), isFromPool) as C2G_Benchmark;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -1053,11 +1287,6 @@ namespace ET
     [Message(OuterMessage.G2C_Benchmark)]
     public partial class G2C_Benchmark : MessageObject, ISessionResponse
     {
-        public static G2C_Benchmark Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_Benchmark), isFromPool) as G2C_Benchmark;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -1066,6 +1295,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static G2C_Benchmark Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            G2C_Benchmark msg = ObjectPool.Instance.Fetch(typeof(G2C_Benchmark), isFromPool) as G2C_Benchmark;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {

--- a/Unity/Assets/Scripts/Model/Generate/Server/Message/ClientMessage_C_1000.cs
+++ b/Unity/Assets/Scripts/Model/Generate/Server/Message/ClientMessage_C_1000.cs
@@ -8,11 +8,6 @@ namespace ET
     [ResponseType(nameof(NetClient2Main_Login))]
     public partial class Main2NetClient_Login : MessageObject, IRequest
     {
-        public static Main2NetClient_Login Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Main2NetClient_Login), isFromPool) as Main2NetClient_Login;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -30,6 +25,33 @@ namespace ET
         /// </summary>
         [MemoryPackOrder(3)]
         public string Password { get; set; }
+
+        /// <summary>
+        /// Create Main2NetClient_Login
+        /// </summary>
+        /// <param name="ownerFiberId">OwnerFiberId</param>
+        /// <param name="account">账号</param>
+        /// <param name="password">密码</param>
+        /// <param name="isFromPool"></param>
+        public static Main2NetClient_Login Create(int ownerFiberId = default, string account = default, string password = default, bool isFromPool = false)
+        {
+            Main2NetClient_Login msg = ObjectPool.Instance.Fetch(typeof(Main2NetClient_Login), isFromPool) as Main2NetClient_Login;
+            msg.Set(ownerFiberId, account, password);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set Main2NetClient_Login
+        /// </summary>
+        /// <param name="ownerFiberId">OwnerFiberId</param>
+        /// <param name="account">账号</param>
+        /// <param name="password">密码</param>
+        public void Set(int ownerFiberId = default, string account = default, string password = default)
+        {
+            this.OwnerFiberId = ownerFiberId;
+            this.Account = account;
+            this.Password = password;
+        }
 
         public override void Dispose()
         {
@@ -51,11 +73,6 @@ namespace ET
     [Message(ClientMessage.NetClient2Main_Login)]
     public partial class NetClient2Main_Login : MessageObject, IResponse
     {
-        public static NetClient2Main_Login Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(NetClient2Main_Login), isFromPool) as NetClient2Main_Login;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -67,6 +84,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public long PlayerId { get; set; }
+
+        public static NetClient2Main_Login Create(int error = default, string message = default, long playerId = default, bool isFromPool = false)
+        {
+            NetClient2Main_Login msg = ObjectPool.Instance.Fetch(typeof(NetClient2Main_Login), isFromPool) as NetClient2Main_Login;
+            msg.Set(error, message, playerId);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, long playerId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.PlayerId = playerId;
+        }
 
         public override void Dispose()
         {

--- a/Unity/Assets/Scripts/Model/Generate/Server/Message/InnerMessage_S_20001.cs
+++ b/Unity/Assets/Scripts/Model/Generate/Server/Message/InnerMessage_S_20001.cs
@@ -8,11 +8,6 @@ namespace ET
     [ResponseType(nameof(ObjectQueryResponse))]
     public partial class ObjectQueryRequest : MessageObject, IRequest
     {
-        public static ObjectQueryRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectQueryRequest), isFromPool) as ObjectQueryRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -21,6 +16,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public long InstanceId { get; set; }
+
+        public static ObjectQueryRequest Create(long key = default, long instanceId = default, bool isFromPool = false)
+        {
+            ObjectQueryRequest msg = ObjectPool.Instance.Fetch(typeof(ObjectQueryRequest), isFromPool) as ObjectQueryRequest;
+            msg.Set(key, instanceId);
+            return msg;
+        }
+
+        public void Set(long key = default, long instanceId = default)
+        {
+            this.Key = key;
+            this.InstanceId = instanceId;
+        }
 
         public override void Dispose()
         {
@@ -42,13 +50,13 @@ namespace ET
     [ResponseType(nameof(A2M_Reload))]
     public partial class M2A_Reload : MessageObject, IRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static M2A_Reload Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(M2A_Reload), isFromPool) as M2A_Reload;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -67,11 +75,6 @@ namespace ET
     [Message(InnerMessage.A2M_Reload)]
     public partial class A2M_Reload : MessageObject, IResponse
     {
-        public static A2M_Reload Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(A2M_Reload), isFromPool) as A2M_Reload;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -80,6 +83,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static A2M_Reload Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            A2M_Reload msg = ObjectPool.Instance.Fetch(typeof(A2M_Reload), isFromPool) as A2M_Reload;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -101,11 +117,6 @@ namespace ET
     [ResponseType(nameof(G2G_LockResponse))]
     public partial class G2G_LockRequest : MessageObject, IRequest
     {
-        public static G2G_LockRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2G_LockRequest), isFromPool) as G2G_LockRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -114,6 +125,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Address { get; set; }
+
+        public static G2G_LockRequest Create(long id = default, string address = default, bool isFromPool = false)
+        {
+            G2G_LockRequest msg = ObjectPool.Instance.Fetch(typeof(G2G_LockRequest), isFromPool) as G2G_LockRequest;
+            msg.Set(id, address);
+            return msg;
+        }
+
+        public void Set(long id = default, string address = default)
+        {
+            this.Id = id;
+            this.Address = address;
+        }
 
         public override void Dispose()
         {
@@ -134,11 +158,6 @@ namespace ET
     [Message(InnerMessage.G2G_LockResponse)]
     public partial class G2G_LockResponse : MessageObject, IResponse
     {
-        public static G2G_LockResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2G_LockResponse), isFromPool) as G2G_LockResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -147,6 +166,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static G2G_LockResponse Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            G2G_LockResponse msg = ObjectPool.Instance.Fetch(typeof(G2G_LockResponse), isFromPool) as G2G_LockResponse;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -168,11 +200,6 @@ namespace ET
     [ResponseType(nameof(G2G_LockReleaseResponse))]
     public partial class G2G_LockReleaseRequest : MessageObject, IRequest
     {
-        public static G2G_LockReleaseRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2G_LockReleaseRequest), isFromPool) as G2G_LockReleaseRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -181,6 +208,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Address { get; set; }
+
+        public static G2G_LockReleaseRequest Create(long id = default, string address = default, bool isFromPool = false)
+        {
+            G2G_LockReleaseRequest msg = ObjectPool.Instance.Fetch(typeof(G2G_LockReleaseRequest), isFromPool) as G2G_LockReleaseRequest;
+            msg.Set(id, address);
+            return msg;
+        }
+
+        public void Set(long id = default, string address = default)
+        {
+            this.Id = id;
+            this.Address = address;
+        }
 
         public override void Dispose()
         {
@@ -201,11 +241,6 @@ namespace ET
     [Message(InnerMessage.G2G_LockReleaseResponse)]
     public partial class G2G_LockReleaseResponse : MessageObject, IResponse
     {
-        public static G2G_LockReleaseResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2G_LockReleaseResponse), isFromPool) as G2G_LockReleaseResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -214,6 +249,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static G2G_LockReleaseResponse Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            G2G_LockReleaseResponse msg = ObjectPool.Instance.Fetch(typeof(G2G_LockReleaseResponse), isFromPool) as G2G_LockReleaseResponse;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -235,11 +283,6 @@ namespace ET
     [ResponseType(nameof(ObjectAddResponse))]
     public partial class ObjectAddRequest : MessageObject, IRequest
     {
-        public static ObjectAddRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectAddRequest), isFromPool) as ObjectAddRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -251,6 +294,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public ActorId ActorId { get; set; }
+
+        public static ObjectAddRequest Create(int type = default, long key = default, ActorId actorId = default, bool isFromPool = false)
+        {
+            ObjectAddRequest msg = ObjectPool.Instance.Fetch(typeof(ObjectAddRequest), isFromPool) as ObjectAddRequest;
+            msg.Set(type, key, actorId);
+            return msg;
+        }
+
+        public void Set(int type = default, long key = default, ActorId actorId = default)
+        {
+            this.Type = type;
+            this.Key = key;
+            this.ActorId = actorId;
+        }
 
         public override void Dispose()
         {
@@ -272,11 +329,6 @@ namespace ET
     [Message(InnerMessage.ObjectAddResponse)]
     public partial class ObjectAddResponse : MessageObject, IResponse
     {
-        public static ObjectAddResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectAddResponse), isFromPool) as ObjectAddResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -285,6 +337,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static ObjectAddResponse Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            ObjectAddResponse msg = ObjectPool.Instance.Fetch(typeof(ObjectAddResponse), isFromPool) as ObjectAddResponse;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -306,11 +371,6 @@ namespace ET
     [ResponseType(nameof(ObjectLockResponse))]
     public partial class ObjectLockRequest : MessageObject, IRequest
     {
-        public static ObjectLockRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectLockRequest), isFromPool) as ObjectLockRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -325,6 +385,21 @@ namespace ET
 
         [MemoryPackOrder(4)]
         public int Time { get; set; }
+
+        public static ObjectLockRequest Create(int type = default, long key = default, ActorId actorId = default, int time = default, bool isFromPool = false)
+        {
+            ObjectLockRequest msg = ObjectPool.Instance.Fetch(typeof(ObjectLockRequest), isFromPool) as ObjectLockRequest;
+            msg.Set(type, key, actorId, time);
+            return msg;
+        }
+
+        public void Set(int type = default, long key = default, ActorId actorId = default, int time = default)
+        {
+            this.Type = type;
+            this.Key = key;
+            this.ActorId = actorId;
+            this.Time = time;
+        }
 
         public override void Dispose()
         {
@@ -347,11 +422,6 @@ namespace ET
     [Message(InnerMessage.ObjectLockResponse)]
     public partial class ObjectLockResponse : MessageObject, IResponse
     {
-        public static ObjectLockResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectLockResponse), isFromPool) as ObjectLockResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -360,6 +430,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static ObjectLockResponse Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            ObjectLockResponse msg = ObjectPool.Instance.Fetch(typeof(ObjectLockResponse), isFromPool) as ObjectLockResponse;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -381,11 +464,6 @@ namespace ET
     [ResponseType(nameof(ObjectUnLockResponse))]
     public partial class ObjectUnLockRequest : MessageObject, IRequest
     {
-        public static ObjectUnLockRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectUnLockRequest), isFromPool) as ObjectUnLockRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -400,6 +478,21 @@ namespace ET
 
         [MemoryPackOrder(4)]
         public ActorId NewActorId { get; set; }
+
+        public static ObjectUnLockRequest Create(int type = default, long key = default, ActorId oldActorId = default, ActorId newActorId = default, bool isFromPool = false)
+        {
+            ObjectUnLockRequest msg = ObjectPool.Instance.Fetch(typeof(ObjectUnLockRequest), isFromPool) as ObjectUnLockRequest;
+            msg.Set(type, key, oldActorId, newActorId);
+            return msg;
+        }
+
+        public void Set(int type = default, long key = default, ActorId oldActorId = default, ActorId newActorId = default)
+        {
+            this.Type = type;
+            this.Key = key;
+            this.OldActorId = oldActorId;
+            this.NewActorId = newActorId;
+        }
 
         public override void Dispose()
         {
@@ -422,11 +515,6 @@ namespace ET
     [Message(InnerMessage.ObjectUnLockResponse)]
     public partial class ObjectUnLockResponse : MessageObject, IResponse
     {
-        public static ObjectUnLockResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectUnLockResponse), isFromPool) as ObjectUnLockResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -435,6 +523,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static ObjectUnLockResponse Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            ObjectUnLockResponse msg = ObjectPool.Instance.Fetch(typeof(ObjectUnLockResponse), isFromPool) as ObjectUnLockResponse;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -456,11 +557,6 @@ namespace ET
     [ResponseType(nameof(ObjectRemoveResponse))]
     public partial class ObjectRemoveRequest : MessageObject, IRequest
     {
-        public static ObjectRemoveRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectRemoveRequest), isFromPool) as ObjectRemoveRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -469,6 +565,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public long Key { get; set; }
+
+        public static ObjectRemoveRequest Create(int type = default, long key = default, bool isFromPool = false)
+        {
+            ObjectRemoveRequest msg = ObjectPool.Instance.Fetch(typeof(ObjectRemoveRequest), isFromPool) as ObjectRemoveRequest;
+            msg.Set(type, key);
+            return msg;
+        }
+
+        public void Set(int type = default, long key = default)
+        {
+            this.Type = type;
+            this.Key = key;
+        }
 
         public override void Dispose()
         {
@@ -489,11 +598,6 @@ namespace ET
     [Message(InnerMessage.ObjectRemoveResponse)]
     public partial class ObjectRemoveResponse : MessageObject, IResponse
     {
-        public static ObjectRemoveResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectRemoveResponse), isFromPool) as ObjectRemoveResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -502,6 +606,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static ObjectRemoveResponse Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            ObjectRemoveResponse msg = ObjectPool.Instance.Fetch(typeof(ObjectRemoveResponse), isFromPool) as ObjectRemoveResponse;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -523,11 +640,6 @@ namespace ET
     [ResponseType(nameof(ObjectGetResponse))]
     public partial class ObjectGetRequest : MessageObject, IRequest
     {
-        public static ObjectGetRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectGetRequest), isFromPool) as ObjectGetRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -536,6 +648,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public long Key { get; set; }
+
+        public static ObjectGetRequest Create(int type = default, long key = default, bool isFromPool = false)
+        {
+            ObjectGetRequest msg = ObjectPool.Instance.Fetch(typeof(ObjectGetRequest), isFromPool) as ObjectGetRequest;
+            msg.Set(type, key);
+            return msg;
+        }
+
+        public void Set(int type = default, long key = default)
+        {
+            this.Type = type;
+            this.Key = key;
+        }
 
         public override void Dispose()
         {
@@ -556,11 +681,6 @@ namespace ET
     [Message(InnerMessage.ObjectGetResponse)]
     public partial class ObjectGetResponse : MessageObject, IResponse
     {
-        public static ObjectGetResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectGetResponse), isFromPool) as ObjectGetResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -575,6 +695,21 @@ namespace ET
 
         [MemoryPackOrder(4)]
         public ActorId ActorId { get; set; }
+
+        public static ObjectGetResponse Create(int error = default, string message = default, int type = default, ActorId actorId = default, bool isFromPool = false)
+        {
+            ObjectGetResponse msg = ObjectPool.Instance.Fetch(typeof(ObjectGetResponse), isFromPool) as ObjectGetResponse;
+            msg.Set(error, message, type, actorId);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, int type = default, ActorId actorId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.Type = type;
+            this.ActorId = actorId;
+        }
 
         public override void Dispose()
         {
@@ -598,16 +733,23 @@ namespace ET
     [ResponseType(nameof(G2R_GetLoginKey))]
     public partial class R2G_GetLoginKey : MessageObject, IRequest
     {
-        public static R2G_GetLoginKey Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(R2G_GetLoginKey), isFromPool) as R2G_GetLoginKey;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public string Account { get; set; }
+
+        public static R2G_GetLoginKey Create(string account = default, bool isFromPool = false)
+        {
+            R2G_GetLoginKey msg = ObjectPool.Instance.Fetch(typeof(R2G_GetLoginKey), isFromPool) as R2G_GetLoginKey;
+            msg.Set(account);
+            return msg;
+        }
+
+        public void Set(string account = default)
+        {
+            this.Account = account;
+        }
 
         public override void Dispose()
         {
@@ -627,11 +769,6 @@ namespace ET
     [Message(InnerMessage.G2R_GetLoginKey)]
     public partial class G2R_GetLoginKey : MessageObject, IResponse
     {
-        public static G2R_GetLoginKey Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2R_GetLoginKey), isFromPool) as G2R_GetLoginKey;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -646,6 +783,21 @@ namespace ET
 
         [MemoryPackOrder(4)]
         public long GateId { get; set; }
+
+        public static G2R_GetLoginKey Create(int error = default, string message = default, long key = default, long gateId = default, bool isFromPool = false)
+        {
+            G2R_GetLoginKey msg = ObjectPool.Instance.Fetch(typeof(G2R_GetLoginKey), isFromPool) as G2R_GetLoginKey;
+            msg.Set(error, message, key, gateId);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, long key = default, long gateId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.Key = key;
+            this.GateId = gateId;
+        }
 
         public override void Dispose()
         {
@@ -668,13 +820,13 @@ namespace ET
     [Message(InnerMessage.G2M_SessionDisconnect)]
     public partial class G2M_SessionDisconnect : MessageObject, ILocationMessage
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static G2M_SessionDisconnect Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(G2M_SessionDisconnect), isFromPool) as G2M_SessionDisconnect;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -693,11 +845,6 @@ namespace ET
     [Message(InnerMessage.ObjectQueryResponse)]
     public partial class ObjectQueryResponse : MessageObject, IResponse
     {
-        public static ObjectQueryResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(ObjectQueryResponse), isFromPool) as ObjectQueryResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -709,6 +856,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public byte[] Entity { get; set; }
+
+        public static ObjectQueryResponse Create(int error = default, string message = default, byte[] entity = default, bool isFromPool = false)
+        {
+            ObjectQueryResponse msg = ObjectPool.Instance.Fetch(typeof(ObjectQueryResponse), isFromPool) as ObjectQueryResponse;
+            msg.Set(error, message, entity);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, byte[] entity = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.Entity = entity;
+        }
 
         public override void Dispose()
         {
@@ -731,11 +892,6 @@ namespace ET
     [ResponseType(nameof(M2M_UnitTransferResponse))]
     public partial class M2M_UnitTransferRequest : MessageObject, IRequest
     {
-        public static M2M_UnitTransferRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2M_UnitTransferRequest), isFromPool) as M2M_UnitTransferRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -747,6 +903,19 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public List<byte[]> Entitys { get; set; } = new();
+
+        public static M2M_UnitTransferRequest Create(ActorId oldActorId = default, byte[] unit = default, bool isFromPool = false)
+        {
+            M2M_UnitTransferRequest msg = ObjectPool.Instance.Fetch(typeof(M2M_UnitTransferRequest), isFromPool) as M2M_UnitTransferRequest;
+            msg.Set(oldActorId, unit);
+            return msg;
+        }
+
+        public void Set(ActorId oldActorId = default, byte[] unit = default)
+        {
+            this.OldActorId = oldActorId;
+            this.Unit = unit;
+        }
 
         public override void Dispose()
         {
@@ -768,11 +937,6 @@ namespace ET
     [Message(InnerMessage.M2M_UnitTransferResponse)]
     public partial class M2M_UnitTransferResponse : MessageObject, IResponse
     {
-        public static M2M_UnitTransferResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2M_UnitTransferResponse), isFromPool) as M2M_UnitTransferResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -781,6 +945,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static M2M_UnitTransferResponse Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            M2M_UnitTransferResponse msg = ObjectPool.Instance.Fetch(typeof(M2M_UnitTransferResponse), isFromPool) as M2M_UnitTransferResponse;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {

--- a/Unity/Assets/Scripts/Model/Generate/Server/Message/LockStepInner_S_21001.cs
+++ b/Unity/Assets/Scripts/Model/Generate/Server/Message/LockStepInner_S_21001.cs
@@ -11,16 +11,23 @@ namespace ET
     [ResponseType(nameof(Match2G_Match))]
     public partial class G2Match_Match : MessageObject, IRequest
     {
-        public static G2Match_Match Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2Match_Match), isFromPool) as G2Match_Match;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public long Id { get; set; }
+
+        public static G2Match_Match Create(long id = default, bool isFromPool = false)
+        {
+            G2Match_Match msg = ObjectPool.Instance.Fetch(typeof(G2Match_Match), isFromPool) as G2Match_Match;
+            msg.Set(id);
+            return msg;
+        }
+
+        public void Set(long id = default)
+        {
+            this.Id = id;
+        }
 
         public override void Dispose()
         {
@@ -40,11 +47,6 @@ namespace ET
     [Message(LockStepInner.Match2G_Match)]
     public partial class Match2G_Match : MessageObject, IResponse
     {
-        public static Match2G_Match Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Match2G_Match), isFromPool) as Match2G_Match;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -53,6 +55,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static Match2G_Match Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            Match2G_Match msg = ObjectPool.Instance.Fetch(typeof(Match2G_Match), isFromPool) as Match2G_Match;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -74,16 +89,16 @@ namespace ET
     [ResponseType(nameof(Map2Match_GetRoom))]
     public partial class Match2Map_GetRoom : MessageObject, IRequest
     {
-        public static Match2Map_GetRoom Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Match2Map_GetRoom), isFromPool) as Match2Map_GetRoom;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public List<long> PlayerIds { get; set; } = new();
+
+        public static Match2Map_GetRoom Create(bool isFromPool = false)
+        {
+            return ObjectPool.Instance.Fetch(typeof(Match2Map_GetRoom), isFromPool) as Match2Map_GetRoom;
+        }
 
         public override void Dispose()
         {
@@ -103,11 +118,6 @@ namespace ET
     [Message(LockStepInner.Map2Match_GetRoom)]
     public partial class Map2Match_GetRoom : MessageObject, IResponse
     {
-        public static Map2Match_GetRoom Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Map2Match_GetRoom), isFromPool) as Map2Match_GetRoom;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -122,6 +132,33 @@ namespace ET
         /// </summary>
         [MemoryPackOrder(3)]
         public ActorId ActorId { get; set; }
+
+        /// <summary>
+        /// Create Map2Match_GetRoom
+        /// </summary>
+        /// <param name="error">错误码</param>
+        /// <param name="message">错误消息</param>
+        /// <param name="actorId">房间的ActorId</param>
+        /// <param name="isFromPool"></param>
+        public static Map2Match_GetRoom Create(int error = default, string message = default, ActorId actorId = default, bool isFromPool = false)
+        {
+            Map2Match_GetRoom msg = ObjectPool.Instance.Fetch(typeof(Map2Match_GetRoom), isFromPool) as Map2Match_GetRoom;
+            msg.Set(error, message, actorId);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set Map2Match_GetRoom
+        /// </summary>
+        /// <param name="error">错误码</param>
+        /// <param name="message">错误消息</param>
+        /// <param name="actorId">房间的ActorId</param>
+        public void Set(int error = default, string message = default, ActorId actorId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.ActorId = actorId;
+        }
 
         public override void Dispose()
         {
@@ -144,16 +181,23 @@ namespace ET
     [ResponseType(nameof(Room2G_Reconnect))]
     public partial class G2Room_Reconnect : MessageObject, IRequest
     {
-        public static G2Room_Reconnect Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2Room_Reconnect), isFromPool) as G2Room_Reconnect;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public long PlayerId { get; set; }
+
+        public static G2Room_Reconnect Create(long playerId = default, bool isFromPool = false)
+        {
+            G2Room_Reconnect msg = ObjectPool.Instance.Fetch(typeof(G2Room_Reconnect), isFromPool) as G2Room_Reconnect;
+            msg.Set(playerId);
+            return msg;
+        }
+
+        public void Set(long playerId = default)
+        {
+            this.PlayerId = playerId;
+        }
 
         public override void Dispose()
         {
@@ -173,11 +217,6 @@ namespace ET
     [Message(LockStepInner.Room2G_Reconnect)]
     public partial class Room2G_Reconnect : MessageObject, IResponse
     {
-        public static Room2G_Reconnect Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Room2G_Reconnect), isFromPool) as Room2G_Reconnect;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -195,6 +234,21 @@ namespace ET
 
         [MemoryPackOrder(5)]
         public int Frame { get; set; }
+
+        public static Room2G_Reconnect Create(int error = default, string message = default, long startTime = default, int frame = default, bool isFromPool = false)
+        {
+            Room2G_Reconnect msg = ObjectPool.Instance.Fetch(typeof(Room2G_Reconnect), isFromPool) as Room2G_Reconnect;
+            msg.Set(error, message, startTime, frame);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, long startTime = default, int frame = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.StartTime = startTime;
+            this.Frame = frame;
+        }
 
         public override void Dispose()
         {
@@ -219,16 +273,16 @@ namespace ET
     [ResponseType(nameof(Room2RoomManager_Init))]
     public partial class RoomManager2Room_Init : MessageObject, IRequest
     {
-        public static RoomManager2Room_Init Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(RoomManager2Room_Init), isFromPool) as RoomManager2Room_Init;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public List<long> PlayerIds { get; set; } = new();
+
+        public static RoomManager2Room_Init Create(bool isFromPool = false)
+        {
+            return ObjectPool.Instance.Fetch(typeof(RoomManager2Room_Init), isFromPool) as RoomManager2Room_Init;
+        }
 
         public override void Dispose()
         {
@@ -248,11 +302,6 @@ namespace ET
     [Message(LockStepInner.Room2RoomManager_Init)]
     public partial class Room2RoomManager_Init : MessageObject, IResponse
     {
-        public static Room2RoomManager_Init Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Room2RoomManager_Init), isFromPool) as Room2RoomManager_Init;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -261,6 +310,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static Room2RoomManager_Init Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            Room2RoomManager_Init msg = ObjectPool.Instance.Fetch(typeof(Room2RoomManager_Init), isFromPool) as Room2RoomManager_Init;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {

--- a/Unity/Assets/Scripts/Model/Generate/Server/Message/LockStepOuter_C_11001.cs
+++ b/Unity/Assets/Scripts/Model/Generate/Server/Message/LockStepOuter_C_11001.cs
@@ -8,13 +8,13 @@ namespace ET
     [ResponseType(nameof(G2C_Match))]
     public partial class C2G_Match : MessageObject, ISessionRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2G_Match Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2G_Match), isFromPool) as C2G_Match;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -33,11 +33,6 @@ namespace ET
     [Message(LockStepOuter.G2C_Match)]
     public partial class G2C_Match : MessageObject, ISessionResponse
     {
-        public static G2C_Match Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_Match), isFromPool) as G2C_Match;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -46,6 +41,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static G2C_Match Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            G2C_Match msg = ObjectPool.Instance.Fetch(typeof(G2C_Match), isFromPool) as G2C_Match;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -69,11 +77,6 @@ namespace ET
     [Message(LockStepOuter.Match2G_NotifyMatchSuccess)]
     public partial class Match2G_NotifyMatchSuccess : MessageObject, IMessage
     {
-        public static Match2G_NotifyMatchSuccess Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Match2G_NotifyMatchSuccess), isFromPool) as Match2G_NotifyMatchSuccess;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -82,6 +85,30 @@ namespace ET
         /// </summary>
         [MemoryPackOrder(1)]
         public ActorId ActorId { get; set; }
+
+        /// <summary>
+        /// Create Match2G_NotifyMatchSuccess
+        /// </summary>
+        /// <param name="rpcId">RpcId</param>
+        /// <param name="actorId">房间的ActorId</param>
+        /// <param name="isFromPool"></param>
+        public static Match2G_NotifyMatchSuccess Create(int rpcId = default, ActorId actorId = default, bool isFromPool = false)
+        {
+            Match2G_NotifyMatchSuccess msg = ObjectPool.Instance.Fetch(typeof(Match2G_NotifyMatchSuccess), isFromPool) as Match2G_NotifyMatchSuccess;
+            msg.Set(rpcId, actorId);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set Match2G_NotifyMatchSuccess
+        /// </summary>
+        /// <param name="rpcId">RpcId</param>
+        /// <param name="actorId">房间的ActorId</param>
+        public void Set(int rpcId = default, ActorId actorId = default)
+        {
+            this.RpcId = rpcId;
+            this.ActorId = actorId;
+        }
 
         public override void Dispose()
         {
@@ -104,13 +131,20 @@ namespace ET
     [Message(LockStepOuter.C2Room_ChangeSceneFinish)]
     public partial class C2Room_ChangeSceneFinish : MessageObject, IRoomMessage
     {
-        public static C2Room_ChangeSceneFinish Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2Room_ChangeSceneFinish), isFromPool) as C2Room_ChangeSceneFinish;
-        }
-
         [MemoryPackOrder(0)]
         public long PlayerId { get; set; }
+
+        public static C2Room_ChangeSceneFinish Create(long playerId = default, bool isFromPool = false)
+        {
+            C2Room_ChangeSceneFinish msg = ObjectPool.Instance.Fetch(typeof(C2Room_ChangeSceneFinish), isFromPool) as C2Room_ChangeSceneFinish;
+            msg.Set(playerId);
+            return msg;
+        }
+
+        public void Set(long playerId = default)
+        {
+            this.PlayerId = playerId;
+        }
 
         public override void Dispose()
         {
@@ -129,11 +163,6 @@ namespace ET
     [Message(LockStepOuter.LockStepUnitInfo)]
     public partial class LockStepUnitInfo : MessageObject
     {
-        public static LockStepUnitInfo Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(LockStepUnitInfo), isFromPool) as LockStepUnitInfo;
-        }
-
         [MemoryPackOrder(0)]
         public long PlayerId { get; set; }
 
@@ -142,6 +171,20 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public TrueSync.TSQuaternion Rotation { get; set; }
+
+        public static LockStepUnitInfo Create(long playerId = default, TrueSync.TSVector position = default, TrueSync.TSQuaternion rotation = default, bool isFromPool = false)
+        {
+            LockStepUnitInfo msg = ObjectPool.Instance.Fetch(typeof(LockStepUnitInfo), isFromPool) as LockStepUnitInfo;
+            msg.Set(playerId, position, rotation);
+            return msg;
+        }
+
+        public void Set(long playerId = default, TrueSync.TSVector position = default, TrueSync.TSQuaternion rotation = default)
+        {
+            this.PlayerId = playerId;
+            this.Position = position;
+            this.Rotation = rotation;
+        }
 
         public override void Dispose()
         {
@@ -165,16 +208,23 @@ namespace ET
     [Message(LockStepOuter.Room2C_Start)]
     public partial class Room2C_Start : MessageObject, IMessage
     {
-        public static Room2C_Start Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Room2C_Start), isFromPool) as Room2C_Start;
-        }
-
         [MemoryPackOrder(0)]
         public long StartTime { get; set; }
 
         [MemoryPackOrder(1)]
         public List<LockStepUnitInfo> UnitInfo { get; set; } = new();
+
+        public static Room2C_Start Create(long startTime = default, bool isFromPool = false)
+        {
+            Room2C_Start msg = ObjectPool.Instance.Fetch(typeof(Room2C_Start), isFromPool) as Room2C_Start;
+            msg.Set(startTime);
+            return msg;
+        }
+
+        public void Set(long startTime = default)
+        {
+            this.StartTime = startTime;
+        }
 
         public override void Dispose()
         {
@@ -194,11 +244,6 @@ namespace ET
     [Message(LockStepOuter.FrameMessage)]
     public partial class FrameMessage : MessageObject, IMessage
     {
-        public static FrameMessage Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(FrameMessage), isFromPool) as FrameMessage;
-        }
-
         [MemoryPackOrder(0)]
         public int Frame { get; set; }
 
@@ -207,6 +252,20 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public LSInput Input { get; set; }
+
+        public static FrameMessage Create(int frame = default, long playerId = default, LSInput input = default, bool isFromPool = false)
+        {
+            FrameMessage msg = ObjectPool.Instance.Fetch(typeof(FrameMessage), isFromPool) as FrameMessage;
+            msg.Set(frame, playerId, input);
+            return msg;
+        }
+
+        public void Set(int frame = default, long playerId = default, LSInput input = default)
+        {
+            this.Frame = frame;
+            this.PlayerId = playerId;
+            this.Input = input;
+        }
 
         public override void Dispose()
         {
@@ -227,14 +286,15 @@ namespace ET
     [Message(LockStepOuter.OneFrameInputs)]
     public partial class OneFrameInputs : MessageObject, IMessage
     {
+        [MongoDB.Bson.Serialization.Attributes.BsonDictionaryOptions(MongoDB.Bson.Serialization.Options.DictionaryRepresentation.ArrayOfArrays)]
+        [MemoryPackOrder(1)]
+        public Dictionary<long, LSInput> Inputs { get; set; } = new();
+
         public static OneFrameInputs Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(OneFrameInputs), isFromPool) as OneFrameInputs;
         }
 
-        [MongoDB.Bson.Serialization.Attributes.BsonDictionaryOptions(MongoDB.Bson.Serialization.Options.DictionaryRepresentation.ArrayOfArrays)]
-        [MemoryPackOrder(1)]
-        public Dictionary<long, LSInput> Inputs { get; set; } = new();
         public override void Dispose()
         {
             if (!this.IsFromPool)
@@ -252,13 +312,20 @@ namespace ET
     [Message(LockStepOuter.Room2C_AdjustUpdateTime)]
     public partial class Room2C_AdjustUpdateTime : MessageObject, IMessage
     {
-        public static Room2C_AdjustUpdateTime Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Room2C_AdjustUpdateTime), isFromPool) as Room2C_AdjustUpdateTime;
-        }
-
         [MemoryPackOrder(0)]
         public int DiffTime { get; set; }
+
+        public static Room2C_AdjustUpdateTime Create(int diffTime = default, bool isFromPool = false)
+        {
+            Room2C_AdjustUpdateTime msg = ObjectPool.Instance.Fetch(typeof(Room2C_AdjustUpdateTime), isFromPool) as Room2C_AdjustUpdateTime;
+            msg.Set(diffTime);
+            return msg;
+        }
+
+        public void Set(int diffTime = default)
+        {
+            this.DiffTime = diffTime;
+        }
 
         public override void Dispose()
         {
@@ -277,11 +344,6 @@ namespace ET
     [Message(LockStepOuter.C2Room_CheckHash)]
     public partial class C2Room_CheckHash : MessageObject, IRoomMessage
     {
-        public static C2Room_CheckHash Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2Room_CheckHash), isFromPool) as C2Room_CheckHash;
-        }
-
         [MemoryPackOrder(0)]
         public long PlayerId { get; set; }
 
@@ -290,6 +352,20 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public long Hash { get; set; }
+
+        public static C2Room_CheckHash Create(long playerId = default, int frame = default, long hash = default, bool isFromPool = false)
+        {
+            C2Room_CheckHash msg = ObjectPool.Instance.Fetch(typeof(C2Room_CheckHash), isFromPool) as C2Room_CheckHash;
+            msg.Set(playerId, frame, hash);
+            return msg;
+        }
+
+        public void Set(long playerId = default, int frame = default, long hash = default)
+        {
+            this.PlayerId = playerId;
+            this.Frame = frame;
+            this.Hash = hash;
+        }
 
         public override void Dispose()
         {
@@ -310,16 +386,24 @@ namespace ET
     [Message(LockStepOuter.Room2C_CheckHashFail)]
     public partial class Room2C_CheckHashFail : MessageObject, IMessage
     {
-        public static Room2C_CheckHashFail Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(Room2C_CheckHashFail), isFromPool) as Room2C_CheckHashFail;
-        }
-
         [MemoryPackOrder(0)]
         public int Frame { get; set; }
 
         [MemoryPackOrder(1)]
         public byte[] LSWorldBytes { get; set; }
+
+        public static Room2C_CheckHashFail Create(int frame = default, byte[] lSWorldBytes = default, bool isFromPool = false)
+        {
+            Room2C_CheckHashFail msg = ObjectPool.Instance.Fetch(typeof(Room2C_CheckHashFail), isFromPool) as Room2C_CheckHashFail;
+            msg.Set(frame, lSWorldBytes);
+            return msg;
+        }
+
+        public void Set(int frame = default, byte[] lSWorldBytes = default)
+        {
+            this.Frame = frame;
+            this.LSWorldBytes = lSWorldBytes;
+        }
 
         public override void Dispose()
         {
@@ -339,11 +423,6 @@ namespace ET
     [Message(LockStepOuter.G2C_Reconnect)]
     public partial class G2C_Reconnect : MessageObject, IMessage
     {
-        public static G2C_Reconnect Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_Reconnect), isFromPool) as G2C_Reconnect;
-        }
-
         [MemoryPackOrder(0)]
         public long StartTime { get; set; }
 
@@ -352,6 +431,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public int Frame { get; set; }
+
+        public static G2C_Reconnect Create(long startTime = default, int frame = default, bool isFromPool = false)
+        {
+            G2C_Reconnect msg = ObjectPool.Instance.Fetch(typeof(G2C_Reconnect), isFromPool) as G2C_Reconnect;
+            msg.Set(startTime, frame);
+            return msg;
+        }
+
+        public void Set(long startTime = default, int frame = default)
+        {
+            this.StartTime = startTime;
+            this.Frame = frame;
+        }
 
         public override void Dispose()
         {

--- a/Unity/Assets/Scripts/Model/Generate/Server/Message/OuterMessage_C_10001.cs
+++ b/Unity/Assets/Scripts/Model/Generate/Server/Message/OuterMessage_C_10001.cs
@@ -7,16 +7,16 @@ namespace ET
     [Message(OuterMessage.HttpGetRouterResponse)]
     public partial class HttpGetRouterResponse : MessageObject
     {
-        public static HttpGetRouterResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(HttpGetRouterResponse), isFromPool) as HttpGetRouterResponse;
-        }
-
         [MemoryPackOrder(0)]
         public List<string> Realms { get; set; } = new();
 
         [MemoryPackOrder(1)]
         public List<string> Routers { get; set; } = new();
+
+        public static HttpGetRouterResponse Create(bool isFromPool = false)
+        {
+            return ObjectPool.Instance.Fetch(typeof(HttpGetRouterResponse), isFromPool) as HttpGetRouterResponse;
+        }
 
         public override void Dispose()
         {
@@ -36,16 +36,24 @@ namespace ET
     [Message(OuterMessage.RouterSync)]
     public partial class RouterSync : MessageObject
     {
-        public static RouterSync Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(RouterSync), isFromPool) as RouterSync;
-        }
-
         [MemoryPackOrder(0)]
         public uint ConnectId { get; set; }
 
         [MemoryPackOrder(1)]
         public string Address { get; set; }
+
+        public static RouterSync Create(uint connectId = default, string address = default, bool isFromPool = false)
+        {
+            RouterSync msg = ObjectPool.Instance.Fetch(typeof(RouterSync), isFromPool) as RouterSync;
+            msg.Set(connectId, address);
+            return msg;
+        }
+
+        public void Set(uint connectId = default, string address = default)
+        {
+            this.ConnectId = connectId;
+            this.Address = address;
+        }
 
         public override void Dispose()
         {
@@ -66,16 +74,23 @@ namespace ET
     [ResponseType(nameof(M2C_TestResponse))]
     public partial class C2M_TestRequest : MessageObject, ILocationRequest
     {
-        public static C2M_TestRequest Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_TestRequest), isFromPool) as C2M_TestRequest;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public string request { get; set; }
+
+        public static C2M_TestRequest Create(string request = default, bool isFromPool = false)
+        {
+            C2M_TestRequest msg = ObjectPool.Instance.Fetch(typeof(C2M_TestRequest), isFromPool) as C2M_TestRequest;
+            msg.Set(request);
+            return msg;
+        }
+
+        public void Set(string request = default)
+        {
+            this.request = request;
+        }
 
         public override void Dispose()
         {
@@ -95,11 +110,6 @@ namespace ET
     [Message(OuterMessage.M2C_TestResponse)]
     public partial class M2C_TestResponse : MessageObject, IResponse
     {
-        public static M2C_TestResponse Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_TestResponse), isFromPool) as M2C_TestResponse;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -111,6 +121,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public string response { get; set; }
+
+        public static M2C_TestResponse Create(int error = default, string message = default, string response = default, bool isFromPool = false)
+        {
+            M2C_TestResponse msg = ObjectPool.Instance.Fetch(typeof(M2C_TestResponse), isFromPool) as M2C_TestResponse;
+            msg.Set(error, message, response);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, string response = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.response = response;
+        }
 
         public override void Dispose()
         {
@@ -133,13 +157,13 @@ namespace ET
     [ResponseType(nameof(G2C_EnterMap))]
     public partial class C2G_EnterMap : MessageObject, ISessionRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2G_EnterMap Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2G_EnterMap), isFromPool) as C2G_EnterMap;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -158,11 +182,6 @@ namespace ET
     [Message(OuterMessage.G2C_EnterMap)]
     public partial class G2C_EnterMap : MessageObject, ISessionResponse
     {
-        public static G2C_EnterMap Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_EnterMap), isFromPool) as G2C_EnterMap;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -177,6 +196,33 @@ namespace ET
         /// </summary>
         [MemoryPackOrder(3)]
         public long MyId { get; set; }
+
+        /// <summary>
+        /// Create G2C_EnterMap
+        /// </summary>
+        /// <param name="error">错误码</param>
+        /// <param name="message">错误消息</param>
+        /// <param name="myId">自己的UnitId</param>
+        /// <param name="isFromPool"></param>
+        public static G2C_EnterMap Create(int error = default, string message = default, long myId = default, bool isFromPool = false)
+        {
+            G2C_EnterMap msg = ObjectPool.Instance.Fetch(typeof(G2C_EnterMap), isFromPool) as G2C_EnterMap;
+            msg.Set(error, message, myId);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set G2C_EnterMap
+        /// </summary>
+        /// <param name="error">错误码</param>
+        /// <param name="message">错误消息</param>
+        /// <param name="myId">自己的UnitId</param>
+        public void Set(int error = default, string message = default, long myId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.MyId = myId;
+        }
 
         public override void Dispose()
         {
@@ -198,11 +244,6 @@ namespace ET
     [Message(OuterMessage.MoveInfo)]
     public partial class MoveInfo : MessageObject
     {
-        public static MoveInfo Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(MoveInfo), isFromPool) as MoveInfo;
-        }
-
         [MemoryPackOrder(0)]
         public List<Unity.Mathematics.float3> Points { get; set; } = new();
 
@@ -211,6 +252,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public int TurnSpeed { get; set; }
+
+        public static MoveInfo Create(Unity.Mathematics.quaternion rotation = default, int turnSpeed = default, bool isFromPool = false)
+        {
+            MoveInfo msg = ObjectPool.Instance.Fetch(typeof(MoveInfo), isFromPool) as MoveInfo;
+            msg.Set(rotation, turnSpeed);
+            return msg;
+        }
+
+        public void Set(Unity.Mathematics.quaternion rotation = default, int turnSpeed = default)
+        {
+            this.Rotation = rotation;
+            this.TurnSpeed = turnSpeed;
+        }
 
         public override void Dispose()
         {
@@ -231,11 +285,6 @@ namespace ET
     [Message(OuterMessage.UnitInfo)]
     public partial class UnitInfo : MessageObject
     {
-        public static UnitInfo Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(UnitInfo), isFromPool) as UnitInfo;
-        }
-
         [MemoryPackOrder(0)]
         public long UnitId { get; set; }
 
@@ -254,8 +303,26 @@ namespace ET
         [MongoDB.Bson.Serialization.Attributes.BsonDictionaryOptions(MongoDB.Bson.Serialization.Options.DictionaryRepresentation.ArrayOfArrays)]
         [MemoryPackOrder(5)]
         public Dictionary<int, long> KV { get; set; } = new();
+
         [MemoryPackOrder(6)]
         public MoveInfo MoveInfo { get; set; }
+
+        public static UnitInfo Create(long unitId = default, int configId = default, int type = default, Unity.Mathematics.float3 position = default, Unity.Mathematics.float3 forward = default, MoveInfo moveInfo = default, bool isFromPool = false)
+        {
+            UnitInfo msg = ObjectPool.Instance.Fetch(typeof(UnitInfo), isFromPool) as UnitInfo;
+            msg.Set(unitId, configId, type, position, forward, moveInfo);
+            return msg;
+        }
+
+        public void Set(long unitId = default, int configId = default, int type = default, Unity.Mathematics.float3 position = default, Unity.Mathematics.float3 forward = default, MoveInfo moveInfo = default)
+        {
+            this.UnitId = unitId;
+            this.ConfigId = configId;
+            this.Type = type;
+            this.Position = position;
+            this.Forward = forward;
+            this.MoveInfo = moveInfo;
+        }
 
         public override void Dispose()
         {
@@ -280,13 +347,13 @@ namespace ET
     [Message(OuterMessage.M2C_CreateUnits)]
     public partial class M2C_CreateUnits : MessageObject, IMessage
     {
+        [MemoryPackOrder(0)]
+        public List<UnitInfo> Units { get; set; } = new();
+
         public static M2C_CreateUnits Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(M2C_CreateUnits), isFromPool) as M2C_CreateUnits;
         }
-
-        [MemoryPackOrder(0)]
-        public List<UnitInfo> Units { get; set; } = new();
 
         public override void Dispose()
         {
@@ -305,13 +372,20 @@ namespace ET
     [Message(OuterMessage.M2C_CreateMyUnit)]
     public partial class M2C_CreateMyUnit : MessageObject, IMessage
     {
-        public static M2C_CreateMyUnit Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_CreateMyUnit), isFromPool) as M2C_CreateMyUnit;
-        }
-
         [MemoryPackOrder(0)]
         public UnitInfo Unit { get; set; }
+
+        public static M2C_CreateMyUnit Create(UnitInfo unit = default, bool isFromPool = false)
+        {
+            M2C_CreateMyUnit msg = ObjectPool.Instance.Fetch(typeof(M2C_CreateMyUnit), isFromPool) as M2C_CreateMyUnit;
+            msg.Set(unit);
+            return msg;
+        }
+
+        public void Set(UnitInfo unit = default)
+        {
+            this.Unit = unit;
+        }
 
         public override void Dispose()
         {
@@ -330,16 +404,24 @@ namespace ET
     [Message(OuterMessage.M2C_StartSceneChange)]
     public partial class M2C_StartSceneChange : MessageObject, IMessage
     {
-        public static M2C_StartSceneChange Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_StartSceneChange), isFromPool) as M2C_StartSceneChange;
-        }
-
         [MemoryPackOrder(0)]
         public long SceneInstanceId { get; set; }
 
         [MemoryPackOrder(1)]
         public string SceneName { get; set; }
+
+        public static M2C_StartSceneChange Create(long sceneInstanceId = default, string sceneName = default, bool isFromPool = false)
+        {
+            M2C_StartSceneChange msg = ObjectPool.Instance.Fetch(typeof(M2C_StartSceneChange), isFromPool) as M2C_StartSceneChange;
+            msg.Set(sceneInstanceId, sceneName);
+            return msg;
+        }
+
+        public void Set(long sceneInstanceId = default, string sceneName = default)
+        {
+            this.SceneInstanceId = sceneInstanceId;
+            this.SceneName = sceneName;
+        }
 
         public override void Dispose()
         {
@@ -359,13 +441,13 @@ namespace ET
     [Message(OuterMessage.M2C_RemoveUnits)]
     public partial class M2C_RemoveUnits : MessageObject, IMessage
     {
+        [MemoryPackOrder(0)]
+        public List<long> Units { get; set; } = new();
+
         public static M2C_RemoveUnits Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(M2C_RemoveUnits), isFromPool) as M2C_RemoveUnits;
         }
-
-        [MemoryPackOrder(0)]
-        public List<long> Units { get; set; } = new();
 
         public override void Dispose()
         {
@@ -384,16 +466,23 @@ namespace ET
     [Message(OuterMessage.C2M_PathfindingResult)]
     public partial class C2M_PathfindingResult : MessageObject, ILocationMessage
     {
-        public static C2M_PathfindingResult Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_PathfindingResult), isFromPool) as C2M_PathfindingResult;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public Unity.Mathematics.float3 Position { get; set; }
+
+        public static C2M_PathfindingResult Create(Unity.Mathematics.float3 position = default, bool isFromPool = false)
+        {
+            C2M_PathfindingResult msg = ObjectPool.Instance.Fetch(typeof(C2M_PathfindingResult), isFromPool) as C2M_PathfindingResult;
+            msg.Set(position);
+            return msg;
+        }
+
+        public void Set(Unity.Mathematics.float3 position = default)
+        {
+            this.Position = position;
+        }
 
         public override void Dispose()
         {
@@ -413,13 +502,13 @@ namespace ET
     [Message(OuterMessage.C2M_Stop)]
     public partial class C2M_Stop : MessageObject, ILocationMessage
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2M_Stop Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2M_Stop), isFromPool) as C2M_Stop;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -438,11 +527,6 @@ namespace ET
     [Message(OuterMessage.M2C_PathfindingResult)]
     public partial class M2C_PathfindingResult : MessageObject, IMessage
     {
-        public static M2C_PathfindingResult Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_PathfindingResult), isFromPool) as M2C_PathfindingResult;
-        }
-
         [MemoryPackOrder(0)]
         public long Id { get; set; }
 
@@ -451,6 +535,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public List<Unity.Mathematics.float3> Points { get; set; } = new();
+
+        public static M2C_PathfindingResult Create(long id = default, Unity.Mathematics.float3 position = default, bool isFromPool = false)
+        {
+            M2C_PathfindingResult msg = ObjectPool.Instance.Fetch(typeof(M2C_PathfindingResult), isFromPool) as M2C_PathfindingResult;
+            msg.Set(id, position);
+            return msg;
+        }
+
+        public void Set(long id = default, Unity.Mathematics.float3 position = default)
+        {
+            this.Id = id;
+            this.Position = position;
+        }
 
         public override void Dispose()
         {
@@ -471,11 +568,6 @@ namespace ET
     [Message(OuterMessage.M2C_Stop)]
     public partial class M2C_Stop : MessageObject, IMessage
     {
-        public static M2C_Stop Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_Stop), isFromPool) as M2C_Stop;
-        }
-
         [MemoryPackOrder(0)]
         public int Error { get; set; }
 
@@ -487,6 +579,21 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public Unity.Mathematics.quaternion Rotation { get; set; }
+
+        public static M2C_Stop Create(int error = default, long id = default, Unity.Mathematics.float3 position = default, Unity.Mathematics.quaternion rotation = default, bool isFromPool = false)
+        {
+            M2C_Stop msg = ObjectPool.Instance.Fetch(typeof(M2C_Stop), isFromPool) as M2C_Stop;
+            msg.Set(error, id, position, rotation);
+            return msg;
+        }
+
+        public void Set(int error = default, long id = default, Unity.Mathematics.float3 position = default, Unity.Mathematics.quaternion rotation = default)
+        {
+            this.Error = error;
+            this.Id = id;
+            this.Position = position;
+            this.Rotation = rotation;
+        }
 
         public override void Dispose()
         {
@@ -509,13 +616,13 @@ namespace ET
     [ResponseType(nameof(G2C_Ping))]
     public partial class C2G_Ping : MessageObject, ISessionRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2G_Ping Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2G_Ping), isFromPool) as C2G_Ping;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -534,11 +641,6 @@ namespace ET
     [Message(OuterMessage.G2C_Ping)]
     public partial class G2C_Ping : MessageObject, ISessionResponse
     {
-        public static G2C_Ping Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_Ping), isFromPool) as G2C_Ping;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -550,6 +652,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public long Time { get; set; }
+
+        public static G2C_Ping Create(int error = default, string message = default, long time = default, bool isFromPool = false)
+        {
+            G2C_Ping msg = ObjectPool.Instance.Fetch(typeof(G2C_Ping), isFromPool) as G2C_Ping;
+            msg.Set(error, message, time);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, long time = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.Time = time;
+        }
 
         public override void Dispose()
         {
@@ -583,7 +699,6 @@ namespace ET
                 return;
             }
 
-            
             ObjectPool.Instance.Recycle(this);
         }
     }
@@ -593,11 +708,6 @@ namespace ET
     [ResponseType(nameof(M2C_Reload))]
     public partial class C2M_Reload : MessageObject, ISessionRequest
     {
-        public static C2M_Reload Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_Reload), isFromPool) as C2M_Reload;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -606,6 +716,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Password { get; set; }
+
+        public static C2M_Reload Create(string account = default, string password = default, bool isFromPool = false)
+        {
+            C2M_Reload msg = ObjectPool.Instance.Fetch(typeof(C2M_Reload), isFromPool) as C2M_Reload;
+            msg.Set(account, password);
+            return msg;
+        }
+
+        public void Set(string account = default, string password = default)
+        {
+            this.Account = account;
+            this.Password = password;
+        }
 
         public override void Dispose()
         {
@@ -626,11 +749,6 @@ namespace ET
     [Message(OuterMessage.M2C_Reload)]
     public partial class M2C_Reload : MessageObject, ISessionResponse
     {
-        public static M2C_Reload Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_Reload), isFromPool) as M2C_Reload;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -639,6 +757,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static M2C_Reload Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            M2C_Reload msg = ObjectPool.Instance.Fetch(typeof(M2C_Reload), isFromPool) as M2C_Reload;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -660,11 +791,6 @@ namespace ET
     [ResponseType(nameof(R2C_Login))]
     public partial class C2R_Login : MessageObject, ISessionRequest
     {
-        public static C2R_Login Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2R_Login), isFromPool) as C2R_Login;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -679,6 +805,30 @@ namespace ET
         /// </summary>
         [MemoryPackOrder(2)]
         public string Password { get; set; }
+
+        /// <summary>
+        /// Create C2R_Login
+        /// </summary>
+        /// <param name="account">帐号</param>
+        /// <param name="password">密码</param>
+        /// <param name="isFromPool"></param>
+        public static C2R_Login Create(string account = default, string password = default, bool isFromPool = false)
+        {
+            C2R_Login msg = ObjectPool.Instance.Fetch(typeof(C2R_Login), isFromPool) as C2R_Login;
+            msg.Set(account, password);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set C2R_Login
+        /// </summary>
+        /// <param name="account">帐号</param>
+        /// <param name="password">密码</param>
+        public void Set(string account = default, string password = default)
+        {
+            this.Account = account;
+            this.Password = password;
+        }
 
         public override void Dispose()
         {
@@ -699,11 +849,6 @@ namespace ET
     [Message(OuterMessage.R2C_Login)]
     public partial class R2C_Login : MessageObject, ISessionResponse
     {
-        public static R2C_Login Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(R2C_Login), isFromPool) as R2C_Login;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -721,6 +866,22 @@ namespace ET
 
         [MemoryPackOrder(5)]
         public long GateId { get; set; }
+
+        public static R2C_Login Create(int error = default, string message = default, string address = default, long key = default, long gateId = default, bool isFromPool = false)
+        {
+            R2C_Login msg = ObjectPool.Instance.Fetch(typeof(R2C_Login), isFromPool) as R2C_Login;
+            msg.Set(error, message, address, key, gateId);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, string address = default, long key = default, long gateId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.Address = address;
+            this.Key = key;
+            this.GateId = gateId;
+        }
 
         public override void Dispose()
         {
@@ -745,11 +906,6 @@ namespace ET
     [ResponseType(nameof(G2C_LoginGate))]
     public partial class C2G_LoginGate : MessageObject, ISessionRequest
     {
-        public static C2G_LoginGate Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2G_LoginGate), isFromPool) as C2G_LoginGate;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -761,6 +917,30 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public long GateId { get; set; }
+
+        /// <summary>
+        /// Create C2G_LoginGate
+        /// </summary>
+        /// <param name="key">帐号</param>
+        /// <param name="gateId">GateId</param>
+        /// <param name="isFromPool"></param>
+        public static C2G_LoginGate Create(long key = default, long gateId = default, bool isFromPool = false)
+        {
+            C2G_LoginGate msg = ObjectPool.Instance.Fetch(typeof(C2G_LoginGate), isFromPool) as C2G_LoginGate;
+            msg.Set(key, gateId);
+            return msg;
+        }
+
+        /// <summary>
+        /// Set C2G_LoginGate
+        /// </summary>
+        /// <param name="key">帐号</param>
+        /// <param name="gateId">GateId</param>
+        public void Set(long key = default, long gateId = default)
+        {
+            this.Key = key;
+            this.GateId = gateId;
+        }
 
         public override void Dispose()
         {
@@ -781,11 +961,6 @@ namespace ET
     [Message(OuterMessage.G2C_LoginGate)]
     public partial class G2C_LoginGate : MessageObject, ISessionResponse
     {
-        public static G2C_LoginGate Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_LoginGate), isFromPool) as G2C_LoginGate;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -797,6 +972,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public long PlayerId { get; set; }
+
+        public static G2C_LoginGate Create(int error = default, string message = default, long playerId = default, bool isFromPool = false)
+        {
+            G2C_LoginGate msg = ObjectPool.Instance.Fetch(typeof(G2C_LoginGate), isFromPool) as G2C_LoginGate;
+            msg.Set(error, message, playerId);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, long playerId = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.PlayerId = playerId;
+        }
 
         public override void Dispose()
         {
@@ -818,13 +1007,20 @@ namespace ET
     [Message(OuterMessage.G2C_TestHotfixMessage)]
     public partial class G2C_TestHotfixMessage : MessageObject, ISessionMessage
     {
-        public static G2C_TestHotfixMessage Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_TestHotfixMessage), isFromPool) as G2C_TestHotfixMessage;
-        }
-
         [MemoryPackOrder(0)]
         public string Info { get; set; }
+
+        public static G2C_TestHotfixMessage Create(string info = default, bool isFromPool = false)
+        {
+            G2C_TestHotfixMessage msg = ObjectPool.Instance.Fetch(typeof(G2C_TestHotfixMessage), isFromPool) as G2C_TestHotfixMessage;
+            msg.Set(info);
+            return msg;
+        }
+
+        public void Set(string info = default)
+        {
+            this.Info = info;
+        }
 
         public override void Dispose()
         {
@@ -844,16 +1040,23 @@ namespace ET
     [ResponseType(nameof(M2C_TestRobotCase))]
     public partial class C2M_TestRobotCase : MessageObject, ILocationRequest
     {
-        public static C2M_TestRobotCase Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_TestRobotCase), isFromPool) as C2M_TestRobotCase;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public int N { get; set; }
+
+        public static C2M_TestRobotCase Create(int n = default, bool isFromPool = false)
+        {
+            C2M_TestRobotCase msg = ObjectPool.Instance.Fetch(typeof(C2M_TestRobotCase), isFromPool) as C2M_TestRobotCase;
+            msg.Set(n);
+            return msg;
+        }
+
+        public void Set(int n = default)
+        {
+            this.N = n;
+        }
 
         public override void Dispose()
         {
@@ -873,11 +1076,6 @@ namespace ET
     [Message(OuterMessage.M2C_TestRobotCase)]
     public partial class M2C_TestRobotCase : MessageObject, ILocationResponse
     {
-        public static M2C_TestRobotCase Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_TestRobotCase), isFromPool) as M2C_TestRobotCase;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -889,6 +1087,20 @@ namespace ET
 
         [MemoryPackOrder(3)]
         public int N { get; set; }
+
+        public static M2C_TestRobotCase Create(int error = default, string message = default, int n = default, bool isFromPool = false)
+        {
+            M2C_TestRobotCase msg = ObjectPool.Instance.Fetch(typeof(M2C_TestRobotCase), isFromPool) as M2C_TestRobotCase;
+            msg.Set(error, message, n);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default, int n = default)
+        {
+            this.Error = error;
+            this.Message = message;
+            this.N = n;
+        }
 
         public override void Dispose()
         {
@@ -910,16 +1122,23 @@ namespace ET
     [Message(OuterMessage.C2M_TestRobotCase2)]
     public partial class C2M_TestRobotCase2 : MessageObject, ILocationMessage
     {
-        public static C2M_TestRobotCase2 Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(C2M_TestRobotCase2), isFromPool) as C2M_TestRobotCase2;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public int N { get; set; }
+
+        public static C2M_TestRobotCase2 Create(int n = default, bool isFromPool = false)
+        {
+            C2M_TestRobotCase2 msg = ObjectPool.Instance.Fetch(typeof(C2M_TestRobotCase2), isFromPool) as C2M_TestRobotCase2;
+            msg.Set(n);
+            return msg;
+        }
+
+        public void Set(int n = default)
+        {
+            this.N = n;
+        }
 
         public override void Dispose()
         {
@@ -939,16 +1158,23 @@ namespace ET
     [Message(OuterMessage.M2C_TestRobotCase2)]
     public partial class M2C_TestRobotCase2 : MessageObject, ILocationMessage
     {
-        public static M2C_TestRobotCase2 Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_TestRobotCase2), isFromPool) as M2C_TestRobotCase2;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
         [MemoryPackOrder(1)]
         public int N { get; set; }
+
+        public static M2C_TestRobotCase2 Create(int n = default, bool isFromPool = false)
+        {
+            M2C_TestRobotCase2 msg = ObjectPool.Instance.Fetch(typeof(M2C_TestRobotCase2), isFromPool) as M2C_TestRobotCase2;
+            msg.Set(n);
+            return msg;
+        }
+
+        public void Set(int n = default)
+        {
+            this.N = n;
+        }
 
         public override void Dispose()
         {
@@ -969,13 +1195,13 @@ namespace ET
     [ResponseType(nameof(M2C_TransferMap))]
     public partial class C2M_TransferMap : MessageObject, ILocationRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2M_TransferMap Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2M_TransferMap), isFromPool) as C2M_TransferMap;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -994,11 +1220,6 @@ namespace ET
     [Message(OuterMessage.M2C_TransferMap)]
     public partial class M2C_TransferMap : MessageObject, ILocationResponse
     {
-        public static M2C_TransferMap Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(M2C_TransferMap), isFromPool) as M2C_TransferMap;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -1007,6 +1228,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static M2C_TransferMap Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            M2C_TransferMap msg = ObjectPool.Instance.Fetch(typeof(M2C_TransferMap), isFromPool) as M2C_TransferMap;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {
@@ -1028,13 +1262,13 @@ namespace ET
     [ResponseType(nameof(G2C_Benchmark))]
     public partial class C2G_Benchmark : MessageObject, ISessionRequest
     {
+        [MemoryPackOrder(0)]
+        public int RpcId { get; set; }
+
         public static C2G_Benchmark Create(bool isFromPool = false)
         {
             return ObjectPool.Instance.Fetch(typeof(C2G_Benchmark), isFromPool) as C2G_Benchmark;
         }
-
-        [MemoryPackOrder(0)]
-        public int RpcId { get; set; }
 
         public override void Dispose()
         {
@@ -1053,11 +1287,6 @@ namespace ET
     [Message(OuterMessage.G2C_Benchmark)]
     public partial class G2C_Benchmark : MessageObject, ISessionResponse
     {
-        public static G2C_Benchmark Create(bool isFromPool = false)
-        {
-            return ObjectPool.Instance.Fetch(typeof(G2C_Benchmark), isFromPool) as G2C_Benchmark;
-        }
-
         [MemoryPackOrder(0)]
         public int RpcId { get; set; }
 
@@ -1066,6 +1295,19 @@ namespace ET
 
         [MemoryPackOrder(2)]
         public string Message { get; set; }
+
+        public static G2C_Benchmark Create(int error = default, string message = default, bool isFromPool = false)
+        {
+            G2C_Benchmark msg = ObjectPool.Instance.Fetch(typeof(G2C_Benchmark), isFromPool) as G2C_Benchmark;
+            msg.Set(error, message);
+            return msg;
+        }
+
+        public void Set(int error = default, string message = default)
+        {
+            this.Error = error;
+            this.Message = message;
+        }
 
         public override void Dispose()
         {


### PR DESCRIPTION
1.由于禁用了new, 现提供类似new的单行创建(Create)和赋值(Set)使用方式
2.不影响现有代码
3.若多参数消息需保持原有写法但又想isFromPool的话可以使用括号内的声明变量形式(例如:C2M_Msg.Create(isFromPool:true);)
4.多参数赋值时也可以选择性赋值(例:M2C_Msg.Set(error:200002);)
5.若proto上有字段的注释, Create和Set方法上也会有对应变量的注释