### PR TITLE
增加编辑器Catch Exception的报错堆栈跳转

### DIFF
--- a/Unity/Assets/Scripts/Editor/LogRedirection/LogRedirection.cs
+++ b/Unity/Assets/Scripts/Editor/LogRedirection/LogRedirection.cs
@@ -26,7 +26,16 @@ namespace ET
             string codePath = AssetDatabase.GetAssetPath(instanceID);
             if (logFileRegex.IsMatch(codePath))
             {
-                Match stackLineMatch = Regex.Match(GetStackTrace(), @"\(at (.+):([0-9]+)\)");
+                var content = GetStackTrace();
+                // 如果有手动输入的地址，就跳过
+                var hrefMath = Regex.Match(content, @"<a href=""(.*?)"" line=""(\w+)\"">.*?</a>");
+                if (hrefMath.Success)
+                {
+                    OpenIDE(hrefMath.Groups[1].Value, int.Parse(hrefMath.Groups[2].Value));
+                    return true;
+                }
+                
+                Match stackLineMatch = Regex.Match(content, @"\(at (.+):([0-9]+)\)");
                 while (stackLineMatch.Success)
                 {
                     codePath = stackLineMatch.Groups[1].Value;

--- a/Unity/Assets/Scripts/Loader/UnityLogger.cs
+++ b/Unity/Assets/Scripts/Loader/UnityLogger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 
 namespace ET
 {
@@ -26,7 +27,21 @@ namespace ET
 
         public void Error(string msg)
         {
+#if UNITY_EDITOR
+            msg = Msg2LinkStackMsg(msg);
+#endif
             UnityEngine.Debug.LogError(msg);
+        }
+        
+        private static string Msg2LinkStackMsg(string msg)
+        {
+            msg = Regex.Replace(msg,@"at (.*?) in (.*?\.cs):(\w+)", match =>
+            {
+                string path = match.Groups[2].Value;
+                string line = match.Groups[3].Value;
+                return $"{match.Groups[1].Value}\n<a href=\"{path}\" line=\"{line}\">{path}:{line}</a>";
+            });
+            return msg;
         }
 
         public void Error(Exception e)


### PR DESCRIPTION
加了个try catch中log.error的异常跳转
![修改前](https://github.com/egametang/ET/assets/41230338/ffa4afaa-e623-4b75-b74d-11b0c7f268dc)
修改前的
![修改后](https://github.com/egametang/ET/assets/41230338/1bc95903-c138-4be8-a863-169f6fd47d3e)
修改后的