### PR TITLE
hotUpdateAssemblies: Unity. -> ET.

### DIFF
--- a/ProjectSettings/HybridCLRSettings.asset
+++ b/ProjectSettings/HybridCLRSettings.asset
@@ -18,10 +18,10 @@ MonoBehaviour:
   il2cppPlusRepoURL: https://gitee.com/focus-creative-games/il2cpp_plus
   hotUpdateAssemblyDefinitions: []
   hotUpdateAssemblies:
-  - Unity.Model
-  - Unity.Hotfix
-  - Unity.ModelView
-  - Unity.HotfixView
+  - ET.Model
+  - ET.Hotfix
+  - ET.ModelView
+  - ET.HotfixView
   preserveHotUpdateAssemblies: []
   hotUpdateDllCompileOutputRootDir: HybridCLRData/HotUpdateDlls
   externalHotUpdateAssembliyDirs:


### PR DESCRIPTION
这个配置改成最新的DLL命名，不然会找不到报错。