### PR TITLE
添加TrueSync Lut相关功能开关宏 DISABLE_FP_SIN_COS_TAN

### DIFF
--- a/Unity/Assets/Scripts/ThirdParty/TrueSync/Fix64.cs
+++ b/Unity/Assets/Scripts/ThirdParty/TrueSync/Fix64.cs
@@ -539,7 +539,7 @@ namespace TrueSync {
             return r;
             //return new FP((long)result);
         }
-
+#if !DISABLE_FP_SIN_COS_TAN
         /// <summary>
         /// Returns the Sine of x.
         /// This function has about 9 decimals of accuracy for small values of x.
@@ -598,7 +598,7 @@ namespace TrueSync {
             return result;
             //return new FP(flipVertical ? -nearestValue : nearestValue);
         }
-
+#endif
 
 
         //[MethodImplAttribute(MethodImplOptions.AggressiveInlining)] 
@@ -625,7 +625,7 @@ namespace TrueSync {
             }
             return clampedPiOver2;
         }
-
+#if !DISABLE_FP_SIN_COS_TAN
         /// <summary>
         /// Returns the cosine of x.
         /// See Sin() for more details.
@@ -636,7 +636,8 @@ namespace TrueSync {
             FP a2 = Sin(new FP(rawAngle));
             return a2;
         }
-
+#endif
+#if !DISABLE_FP_SIN_COS_TAN
         /// <summary>
         /// Returns a rough approximation of the cosine of x.
         /// See FastSin for more details.
@@ -646,7 +647,8 @@ namespace TrueSync {
             var rawAngle = xl + (xl > 0 ? -PI - PI_OVER_2 : PI_OVER_2);
             return FastSin(new FP(rawAngle));
         }
-
+#endif
+#if !DISABLE_FP_SIN_COS_TAN
         /// <summary>
         /// Returns the tangent of x.
         /// </summary>
@@ -681,6 +683,7 @@ namespace TrueSync {
             FP a2 = new FP(finalValue);
             return a2;
         }
+#endif
 
         /// <summary>
         /// Returns the arctan of of the specified number, calculated using Euler series

--- a/Unity/Assets/Scripts/ThirdParty/TrueSync/Fix64AcosLut.cs
+++ b/Unity/Assets/Scripts/ThirdParty/TrueSync/Fix64AcosLut.cs
@@ -1,3 +1,4 @@
+#if !DISABLE_FP_SIN_COS_TAN
 namespace TrueSync {
     partial struct FP {
         public static readonly long[] AcosLut = new[] {
@@ -25740,3 +25741,4 @@ namespace TrueSync {
         };
     }
 }
+#endif

--- a/Unity/Assets/Scripts/ThirdParty/TrueSync/Fix64SinLut.cs
+++ b/Unity/Assets/Scripts/ThirdParty/TrueSync/Fix64SinLut.cs
@@ -1,3 +1,4 @@
+#if !DISABLE_FP_SIN_COS_TAN
 namespace TrueSync {
     partial struct FP {
         public static readonly long[] SinLut = new[] {
@@ -25740,3 +25741,4 @@ namespace TrueSync {
         };
     }
 }
+#endif

--- a/Unity/Assets/Scripts/ThirdParty/TrueSync/Fix64TanLut.cs
+++ b/Unity/Assets/Scripts/ThirdParty/TrueSync/Fix64TanLut.cs
@@ -1,3 +1,4 @@
+#if !DISABLE_FP_SIN_COS_TAN
 namespace TrueSync {
     partial struct FP {
         public static readonly long[] TanLut = new[] {
@@ -25740,3 +25741,4 @@ namespace TrueSync {
         };
     }
 }
+#endif

--- a/Unity/Assets/Scripts/ThirdParty/TrueSync/TSMath.cs
+++ b/Unity/Assets/Scripts/ThirdParty/TrueSync/TSMath.cs
@@ -150,6 +150,7 @@ namespace TrueSync {
         /// <param name="matrix">The matrix.</param>
         /// <param name="result">The absolute matrix.</param>
         #region public static void Absolute(ref JMatrix matrix,out JMatrix result)
+#if !DISABLE_FP_SIN_COS_TAN
         public static void Absolute(ref TSMatrix matrix, out TSMatrix result) {
             result.M11 = FP.Abs(matrix.M11);
             result.M12 = FP.Abs(matrix.M12);
@@ -161,8 +162,10 @@ namespace TrueSync {
             result.M32 = FP.Abs(matrix.M32);
             result.M33 = FP.Abs(matrix.M33);
         }
+#endif
         #endregion
 
+#if !DISABLE_FP_SIN_COS_TAN
         /// <summary>
         /// Returns the sine of value.
         /// </summary>
@@ -183,6 +186,7 @@ namespace TrueSync {
         public static FP Tan(FP value) {
             return FP.Tan(value);
         }
+#endif
 
         /// <summary>
         /// Returns the arc sine of value.

--- a/Unity/Assets/Scripts/ThirdParty/TrueSync/TSMatrix.cs
+++ b/Unity/Assets/Scripts/ThirdParty/TrueSync/TSMatrix.cs
@@ -19,7 +19,7 @@
 
 namespace TrueSync
 {
-
+#if !DISABLE_FP_SIN_COS_TAN
     /// <summary>
     /// 3x3 Matrix.
     /// </summary>
@@ -702,5 +702,5 @@ namespace TrueSync
         }
 
     }
-
+#endif
 }

--- a/Unity/Assets/Scripts/ThirdParty/TrueSync/TSMatrix4x4.cs
+++ b/Unity/Assets/Scripts/ThirdParty/TrueSync/TSMatrix4x4.cs
@@ -19,7 +19,7 @@
 
 namespace TrueSync
 {
-
+#if !DISABLE_FP_SIN_COS_TAN
     /// <summary>
     /// 3x3 Matrix.
     /// </summary>
@@ -1194,5 +1194,5 @@ namespace TrueSync
             return result;
         }
     }
-
+#endif
 }

--- a/Unity/Assets/Scripts/ThirdParty/TrueSync/TSQuaternion.cs
+++ b/Unity/Assets/Scripts/ThirdParty/TrueSync/TSQuaternion.cs
@@ -22,6 +22,7 @@ using System;
 namespace TrueSync
 {
 
+#if !DISABLE_FP_SIN_COS_TAN
     /// <summary>
     /// A Quaternion representing an orientation.
     /// </summary>
@@ -519,4 +520,5 @@ namespace TrueSync
         }
 
     }
+#endif
 }

--- a/Unity/Assets/Scripts/ThirdParty/TrueSync/TSVector.cs
+++ b/Unity/Assets/Scripts/ThirdParty/TrueSync/TSVector.cs
@@ -369,6 +369,7 @@ namespace TrueSync
         /// <param name="matrix">The transform matrix.</param>
         /// <returns>The transformed vector.</returns>
         #region public static JVector Transform(JVector position, JMatrix matrix)
+#if !DISABLE_FP_SIN_COS_TAN
         public static TSVector Transform(TSVector position, TSMatrix matrix)
         {
             TSVector result;
@@ -409,6 +410,7 @@ namespace TrueSync
             result.y = num1;
             result.z = num2;
         }
+#endif
         #endregion
 
         /// <summary>

--- a/Unity/Assets/Scripts/ThirdParty/TrueSync/TSVector4.cs
+++ b/Unity/Assets/Scripts/ThirdParty/TrueSync/TSVector4.cs
@@ -362,6 +362,7 @@ namespace TrueSync
         /// <param name="matrix">The transform matrix.</param>
         /// <returns>The transformed vector.</returns>
         #region public static JVector Transform(JVector position, JMatrix matrix)
+#if !DISABLE_FP_SIN_COS_TAN
         public static TSVector4 Transform(TSVector4 position, TSMatrix4x4 matrix)
         {
             TSVector4 result;
@@ -397,6 +398,7 @@ namespace TrueSync
             result.z = vector.x * matrix.M31 + vector.y * matrix.M32 + vector.z * matrix.M33 + vector.w * matrix.M34;
             result.w = vector.x * matrix.M41 + vector.y * matrix.M42 + vector.z * matrix.M43 + vector.w * matrix.M44;
         }
+#endif
         #endregion
 
         /// <summary>


### PR DESCRIPTION
 打包后Lut代码文件会占用5m左右, 不需要sin cos tan matrix Quaternion等功能时 可以开启宏以减小包体积