### PR TITLE
ET6 处理-打包时抛例外

### DIFF
--- a/Unity/Assets/Mono/Core/Helper/FileHelper.cs
+++ b/Unity/Assets/Mono/Core/Helper/FileHelper.cs
@@ -23,14 +23,16 @@ namespace ET
 		
 		public static void CleanDirectory(string dir)
 		{
-			foreach (string subdir in Directory.GetDirectories(dir))
-			{
-				Directory.Delete(subdir, true);		
-			}
+			if (Directory.Exists(dir)) {
+				foreach (string subdir in Directory.GetDirectories(dir))
+				{
+					Directory.Delete(subdir, true);		
+				}
 
-			foreach (string subFile in Directory.GetFiles(dir))
-			{
-				File.Delete(subFile);
+				foreach (string subFile in Directory.GetFiles(dir))
+				{
+					File.Delete(subFile);
+				}
 			}
 		}
 


### PR DESCRIPTION
处理-打包时抛例外；原因-清理旧AB包目录时，未先检查是否存在？就进行存取